### PR TITLE
feat(api): add category count stats endpoint for projects

### DIFF
--- a/server/api/projects/stats.get.ts
+++ b/server/api/projects/stats.get.ts
@@ -1,0 +1,14 @@
+export default defineEventHandler(async (event): Promise<CategoryCount[]> => {
+  const statement = event.context.database.prepare(`
+    SELECT
+      category,
+      COUNT(*) AS count
+    FROM projects
+    GROUP BY category
+    ORDER BY
+      count DESC,
+      category COLLATE NOCASE ASC
+  `)
+
+  return await statement.all() as CategoryCount[]
+})

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -11,6 +11,11 @@ export interface ProjectRecord {
   stars: number
 }
 
+export interface CategoryCount {
+  category: string
+  count: number
+}
+
 export interface ProjectFilters {
   category?: string
   source?: string


### PR DESCRIPTION
### Background

目前 `/api/projects` 只返回明细列表,调用方无法直接获知 projects 主表各分类的收录规模,需要拉取全量数据后自行聚合。本次新增一个轻量统计接口,按 category 分组返回收录数量。

### Changes

- 新增 `GET /api/projects/stats`:对 projects 表执行 `GROUP BY category` 统计,返回 `CategoryCount[]`(`{ category, count }`),按 count 降序、分类名不分大小写升序排列
- `shared/types/project.ts` 新增返回类型 `CategoryCount`,沿用 shared/types 自动导入约定
- 复用现有数据库插件注入的 `event.context.database`,不引入新依赖

### Related Issues

None

### Verification

- `pnpm lint` 通过
- `pnpm typecheck` 通过(仓库未声明 vue-tsc,临时安装后执行;此为既有环境情况,未包含在本 PR)
- dev 环境实测 `GET /api/projects/stats` 返回各分类统计:plugin 2922 / nuxt 436 / component 58 / admin 55 / ui 27 / uniapp 24 / hooks 17
- 原有 `/api/projects` 路由不受新增嵌套路由影响