### PR TITLE
docs(schema): clarify project icon sources

### DIFF
--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -94,7 +94,11 @@ export interface CommunityProject {
   name: string
   description: string
 
-  /** 本地图标名（app/assets/icon 下的 svg，去掉 .svg 后缀），无图标时为空字符串 */
+  /**
+   * Local icon name (svg under app/assets/icon without the.svg suffix),
+   * or https://icon-sets.iconify.design/ icon name,
+   * or an empty string when no icon is present
+   */
   icon: string
 
   category: ProjectCategory


### PR DESCRIPTION
### Background

The `CommunityProject.icon` documentation only described local SVG icons and did not cover Iconify icon names.

### Changes

- Translate the `icon` field documentation into English.
- Document support for local SVG names, Iconify icon names, and empty values.

### Related Issues

None

### Verification

- The pre-commit ESLint check passed.
- Full `pnpm lint` and `pnpm typecheck` were not run because this environment requires developer-run validation.