### PR TITLE
docs: restructure contributing guide and add Chinese version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,43 +1,45 @@
 # Contributing Guide
 
-Thank you for wanting to contribute to Vue Community! This document covers environment setup, project structure, common commands, and commit conventions to help you get started quickly.
+Thank you for wanting to contribute to Vuejs Community! This document covers environment requirements, the quick start process, project structure, data maintenance, and commit conventions to help you get involved quickly.
 
 ## Table of Contents
 
 - [Requirements](#requirements)
 - [Quick Start](#quick-start)
 - [Project Structure](#project-structure)
-- [Common Commands](#common-commands)
-- [How to Contribute](#how-to-contribute)
-- [Development Workflow](#development-workflow)
-- [Commit Convention (Conventional Commits)](#commit-convention-conventional-commits)
+- [Maintaining Open Source Component Data](#maintaining-open-source-component-data)
+- [defineProjectMeta Field Reference](#defineprojectmeta-field-reference)
+- [PR Guidelines (Conventional Commits)](#pr-guidelines-conventional-commits)
+- [Final Words](#final-words)
 
 ## Requirements
 
+Before getting started, please make sure your local environment meets the following hard requirements:
+
 | Tool | Version | Notes |
 | --- | --- | --- |
-| Node.js | ≥ 22 (LTS recommended) | CI uses `lts/*` |
-| pnpm | 11.x | Locked to `pnpm@11.24.0` via the `packageManager` field; install with `corepack enable` or `npm i -g pnpm` |
+| Node.js | **>= 22** | LTS version recommended; CI uses `lts/*` |
+| pnpm | **> v11.x** | The project pins the version via the `packageManager` field; `corepack enable` is recommended |
 | Git | A recent version | Commit hooks rely on `simple-git-hooks` |
 
 ## Quick Start
 
+Follow these three steps to run the docs site locally:
+
 ```bash
-# 1. Fork the repository, then clone it (or clone your existing fork directly)
-git clone https://github.com/<your-username>/vuejs-community.git
+# 1. Clone the project (if you have your own fork, replace with your repository URL)
+git clone https://github.com/vuejs-community/vuejs-community.git
+
+# 2. Enter the project directory and install dependencies
 cd vuejs-community
-
-# 2. Use the pnpm version pinned by the project
-corepack enable
-
-# 3. Install dependencies
-#    postinstall runs nuxt prepare automatically,
-#    and the prepare script registers the simple-git-hooks commit hooks
 pnpm install
 
-# 4. Start the dev server (http://localhost:3000)
-pnpm docs:dev
+# 3. Run the docs site in dev mode (default: http://localhost:3000)
+pnpm run docs:dev
 ```
+
+> [!TIP]
+> `pnpm install` automatically runs `nuxt prepare` and registers Git commit hooks (pre-commit runs `eslint --fix`, commit-msg validates the commit message format) — no extra configuration needed.
 
 ## Project Structure
 
@@ -50,11 +52,13 @@ pnpm docs:dev
 │   ├── api/                 # API routes
 │   └── assets/              # Location of the generated index.db
 ├── packages/
-│   ├── data-component/      # Vue component library data
-│   ├── data-hooks/          # Composables data
-│   ├── data-nuxt/           # Nuxt module data
-│   ├── data-plugins/        # Vite / Rollup / Rolldown / Unplugin plugin data
-│   ├── data-ui/             # UI component library data
+│   ├── data-ui/             # UI component library data ✅ maintainable
+│   ├── data-component/      # Component library data ✅ maintainable
+│   ├── data-hooks/          # Composables data ✅ maintainable
+│   ├── data-admin/          # Admin template data ✅ maintainable
+│   ├── data-uniapp/         # UniApp ecosystem data ✅ maintainable
+│   ├── data-nuxt/           # Nuxt module data 🤖 auto-synced by scripts, do NOT edit manually
+│   ├── data-plugins/        # Build plugin data 🤖 auto-synced by scripts, do NOT edit manually
 │   ├── schema/              # @vuejs-community/schema data type definitions
 │   ├── shared/              # @vuejs-community/shared utility functions
 │   └── tsconfig/            # Shared TypeScript configuration
@@ -63,67 +67,108 @@ pnpm docs:dev
 └── turbo.json               # Turborepo task configuration
 ```
 
-## Common Commands
+## Maintaining Open Source Component Data
 
-| Command | Description |
+Maintenance of community open source project data is **only supported in the following directories**, one `.ts` file per project:
+
+| Directory | Content |
 | --- | --- |
-| `pnpm docs:dev` | Start the Nuxt dev server (localhost:3000) |
-| `pnpm build` | Production build |
-| `pnpm generate` | Static site generation |
-| `pnpm preview` | Preview the production build |
-| `pnpm typecheck` | Run `nuxt typecheck` |
-| `pnpm lint` | Run ESLint |
-| `pnpm lint:fix` | Auto-fix ESLint issues |
-| `pnpm generate:plugins` | Sync Vite / Rollup / Rolldown / Unplugin plugin data |
-| `pnpm generate:nuxt:modules` | Sync Nuxt module data |
-| `pnpm generate:db` | Rebuild index.db under `server/assets` |
-| `pnpm sync:npm-git-data` | Sync npm download and GitHub Stars data |
-| `pnpm -F <package-name> run <script>` | Run a script inside a specific workspace package, e.g. `pnpm -F @vuejs-community/shared run dev` |
+| `packages/data-ui/` | UI component libraries |
+| `packages/data-component/` | Component libraries / collections |
+| `packages/data-hooks/` | Composables / Hooks libraries |
+| `packages/data-admin/` | Admin dashboard templates |
+| `packages/data-uniapp/` | UniApp ecosystem projects |
 
-## How to Contribute
+> [!IMPORTANT]
+> **`packages/data-nuxt/` and `packages/data-plugins/` do not accept manual data edits.**
+>
+> Data in these two directories is generated by repository scripts that run on a regular schedule; manual changes will be overwritten. If you find data issues there or want to adjust the sync logic, please only modify the `scripts/` in the corresponding subproject and improve the sync logic itself via a PR.
 
-### Add a New Project / Fix Data
+After adding or modifying data, run the following command to rebuild the index database so the site reads the latest data:
 
-Site data lives as TypeScript files under `packages/data-*`, one file per project, defined with `defineProjectMeta` from `@vuejs-community/schema`:
+```bash
+pnpm generate:db
+```
 
-- Nuxt modules: `packages/data-nuxt/src/<module-name>.ts`
-- Plugins: `packages/data-plugins/src/<vite|rollup|rolldown|unplugin>/<plugin-name>.ts`
+## defineProjectMeta Field Reference
+
+All data entries are defined with `defineProjectMeta` from `@vuejs-community/schema`, which provides full type hints. Below is a fully commented example:
 
 ```ts
 import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
-  name: 'my-awesome-plugin',
-  description: 'What it does, in one sentence',
-  category: 'plugin',
-  tags: ['vite'],
-  types: ['vite-plugin'],
+  // Project name, must match the real package / repository name
+  name: 'ant-design-vue',
+
+  // One-sentence description of what the project does
+  description: 'Enterprise-level UI components based on Ant Design and Vue',
+
+  // Icon: local icon name (svg under app/assets/icon, without the .svg suffix)
+  // or an iconify icon name (e.g. 'logos:vue'); pass an empty string if there is none
+  icon: 'icon:ant-design-vue',
+
+  // Project category: 'ui' | 'hooks' | 'component' | 'admin' | 'uniapp' etc.
+  category: 'ui',
+
+  // Project type list, e.g. 'ui-library', 'composable-library', etc.
+  types: ['ui-library'],
+
+  // Optional: tags for filtering and searching within the site
+  tags: ['ui', 'ant-design'],
+
+  // Data source, used by scripts to fetch stats such as Stars / downloads
+  // github uses the 'owner/repo' format; npm takes the package name directly
+  source: {
+    github: 'vueComponent/ant-design-vue',
+    npm: 'ant-design-vue',
+  },
+
+  // Optional: links shown publicly
   links: {
-    github: 'https://github.com/user/my-awesome-plugin',
-    npm: 'https://www.npmjs.com/package/my-awesome-plugin',
+    github: 'https://github.com/vueComponent/ant-design-vue',
+    npm: 'https://www.npmjs.com/package/ant-design-vue',
+    website: 'https://antdv.com',
+  },
+
+  // Stats (Stars, downloads) are synced automatically by scheduled jobs, no manual maintenance needed
+  stats: {
+    stars: 21641,
+    downloads: {
+      monthly: 942627,
+      weekly: 168488,
+    },
   },
 })
 ```
 
 Notes:
 
-- `name`, `links.github`, and `links.npm` must match the real repository / package names; the data sync scripts rely on these fields to pull information.
-- `stats` (Stars, downloads, etc.) are synced automatically by scheduled jobs, so **no manual maintenance is needed**; you can also run `pnpm sync:npm-git-data` locally to refresh them manually.
-- After adding or modifying data, run `pnpm generate:db` to rebuild the index database so the site can read the latest data.
-- The repository runs a data sync workflow daily that automatically updates module / plugin data and the database, so changes related to stats usually don't need to be committed manually.
+- `name`, `source.github`, and `source.npm` must match the real repository / package names, since the data sync scripts rely on these fields to fetch information.
+- `stats` is updated automatically by scheduled jobs and requires **no manual maintenance**; you can also run `pnpm sync:npm-git-data` locally to refresh them manually.
+- To add new fields, update the type definitions in `packages/schema/` first.
 
-### Improve Site Features and UI
+## PR Guidelines (Conventional Commits)
 
-- Site code lives in `app/`, and server APIs live in `server/api/`.
-- UI components are based on shadcn-vue + Tailwind CSS v4. When adding a base component, use the shadcn-vue CLI to generate it into `app/components/ui/`.
-- Icons use `@nuxt/icon`; local custom icons go in `app/assets/icon/`.
-- Data types are imported from `@vuejs-community/schema`; update the schema first if you need to add fields.
+When submitting a PR, please strictly follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) convention. The repository has `verify-git-commit` enabled to validate commit messages; commits that don't follow the format will be rejected:
 
-### Reporting Issues
+```
+type(scope): subject
+```
 
-When filing an issue, please describe the expected behavior, the actual behavior, reproduction steps, and environment info (browser / Node version). If you find incorrect data entries, attaching the file path of the corresponding entry or the project name is enough — no need for full screenshots.
+- **type**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
+- **scope** (optional): the module the change belongs to, e.g. `db`, `data-ui`, `data-nuxt`, `schema`, `shared`, `ui`, `deps`
+- **subject**: a short description, starting lowercase, without a trailing period
 
-## Development Workflow
+Examples:
+
+```
+feat(data-ui): add ant-design-vue entry
+fix(db): handle missing tags in index db generation
+chore(deps): update nuxt to latest
+```
+
+Submission process:
 
 1. Create a feature branch from the latest `master`:
 
@@ -131,40 +176,19 @@ When filing an issue, please describe the expected behavior, the actual behavior
    git checkout -b feat/my-feature
    ```
 
-2. When you're done, make sure the following checks pass:
+2. Make sure the following checks pass before committing:
 
    ```bash
    pnpm lint
    pnpm typecheck
    ```
 
-3. Submit a PR to `master` and describe the changes and motivation in the description; for data PRs, note which entries are affected.
+3. Submit a PR to `master` and describe the changes and motivation; for data PRs, note which entries are affected.
 
-## Commit Convention (Conventional Commits)
+## Final Words
 
-The repository enables `verify-git-commit` to validate commit messages; commits that don't follow the format will be rejected:
+**Don't be afraid of making mistakes — be bold and just do it.**
 
-```
-type(scope): subject
-```
+Every mature repository has grown through countless trials and errors. A bad commit can be fixed, an imperfect PR will be kindly reviewed by maintainers, and no one will blame you for a single mistake — that is exactly what makes the open source world so wonderful.
 
-- **type**: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
-- **scope** (optional): the module the change belongs to, e.g. `db`, `data-nuxt`, `data-plugins`, `schema`, `shared`, `ui`, `deps`
-- **subject**: a short description, starting lowercase, without a trailing period
-
-Examples:
-
-```
-feat(data-plugins): add unplugin-icons entry
-fix(db): handle missing tags in index db generation
-chore(deps): update nuxt to latest
-```
-
-Git hook behavior (registered automatically by `pnpm install`):
-
-- **pre-commit**: `lint-staged` runs `eslint --fix` on staged files automatically
-- **commit-msg**: `verify-git-commit` validates the commit message format
-
-## Reference
-
-When creating a PR, use the repository's built-in `create-pr` skill (`.agents/skills/create-pr/SKILL.md`) directly. It defines the complete conventions and examples for PR titles and bodies: titles follow the Conventional Commits format above, bodies include background, changes, related issues, and verification steps, and a draft is output for confirmation before creating the PR.
+The open source world welcomes everyone, and the Vue.js community looks forward to growing stronger with all of you. We can't wait to see your name in the contributors list! 🚀

--- a/CONTRIBUTING_CN.md
+++ b/CONTRIBUTING_CN.md
@@ -1,0 +1,194 @@
+# 贡献指南
+
+感谢你愿意为 Vuejs Community 做出贡献！本文档介绍环境要求、快速上手流程、项目结构以及数据维护与提交规范，帮助你快速参与进来。
+
+## 目录
+
+- [环境要求](#环境要求)
+- [快速开始](#快速开始)
+- [项目结构](#项目结构)
+- [开源组件数据维护](#开源组件数据维护)
+- [defineProjectMeta 字段说明](#defineprojectmeta-字段说明)
+- [提交 PR 规范（Conventional Commits）](#提交-pr-规范conventional-commits)
+- [写在最后](#写在最后)
+
+## 环境要求
+
+在开始之前，请确保你的本地环境满足以下硬性要求：
+
+| 工具 | 版本要求 | 说明 |
+| --- | --- | --- |
+| Node.js | **>= 22** | 建议 use LTS 版本，CI 环境使用 `lts/*` |
+| pnpm | **> v11.x** | 项目通过 `packageManager` 字段锁定版本，推荐使用 `corepack enable` 启用 |
+| Git | 较新版本即可 | 提交钩子依赖 `simple-git-hooks` |
+
+## 快速开始
+
+按照以下三步即可在本地跑起文档站点：
+
+```bash
+# 1. 克隆项目（如果是你自己的 Fork，请替换成你的仓库地址）
+git clone https://github.com/vuejs-community/vuejs-community.git
+
+# 2. 进入项目目录并安装依赖
+cd vuejs-community
+pnpm install
+
+# 3. 运行调试文档站点（默认 http://localhost:3000）
+pnpm run docs:dev
+```
+
+> [!TIP]
+> `pnpm install` 会自动执行 `nuxt prepare` 并注册 Git 提交钩子（pre-commit 执行 `eslint --fix`，commit-msg 校验提交信息格式），无需额外配置。
+
+## 项目结构
+
+```
+.
+├── app/                     # Nuxt 应用（页面、组件、布局、静态资源等）
+│   ├── components/ui/       # shadcn-vue 生成的 UI 组件
+│   └── assets/icon/         # 本地自定义图标（@nuxt/icon 自定义集合）
+├── server/                  # Nitro 服务端
+│   ├── api/                 # API 路由
+│   └── assets/              # 生成后的 index.db 存放位置
+├── packages/
+│   ├── data-ui/             # UI 组件库数据 ✅ 可维护
+│   ├── data-component/      # 组件库数据 ✅ 可维护
+│   ├── data-hooks/          # Composables 数据 ✅ 可维护
+│   ├── data-admin/          # 后台模板 / Admin 数据 ✅ 可维护
+│   ├── data-uniapp/         # UniApp 生态数据 ✅ 可维护
+│   ├── data-nuxt/           # Nuxt 模块数据 🤖 由脚本自动同步，勿手动修改
+│   ├── data-plugins/        # 构建插件数据 🤖 由脚本自动同步，勿手动修改
+│   ├── schema/              # @vuejs-community/schema 数据类型定义
+│   ├── shared/              # @vuejs-community/shared 工具函数
+│   └── tsconfig/            # 共享 TypeScript 配置
+├── scripts/                 # 仓库级数据同步脚本
+├── shared/                  # 顶层共享类型
+└── turbo.json               # Turborepo 任务配置
+```
+
+## 开源组件数据维护
+
+社区开源组件数据的维护**仅支持以下目录**，每个项目一个 `.ts` 文件：
+
+| 目录 | 内容 |
+| --- | --- |
+| `packages/data-ui/` | UI 组件库 |
+| `packages/data-component/` | 组件库 / 组件集合 |
+| `packages/data-hooks/` | Composables / Hooks 库 |
+| `packages/data-admin/` | Admin 后台模板 |
+| `packages/data-uniapp/` | UniApp 生态项目 |
+
+> [!IMPORTANT]
+> **`packages/data-nuxt/` 和 `packages/data-plugins/` 不接受手动修改数据。**
+>
+> 这两个目录的数据由仓库脚本定期自动执行同步生成，手动改动会被覆盖。如果发现其中的数据有问题、需要调整同步逻辑，请只修改对应子项目中的 `scripts/` 脚本，通过 PR 的方式改进同步逻辑本身。
+
+新增或修改数据后，请运行以下命令重建索引数据库，让站点读取到最新数据：
+
+```bash
+pnpm generate:db
+```
+
+## defineProjectMeta 字段说明
+
+所有数据条目均使用 `@vuejs-community/schema` 提供的 `defineProjectMeta` 定义，带有完整的类型提示。以下是一个带注释的完整示例：
+
+```ts
+import { defineProjectMeta } from '@vuejs-community/schema'
+
+export default defineProjectMeta({
+  // 项目名称，必须与真实包名 / 仓库名一致
+  name: 'ant-design-vue',
+
+  // 一句话描述项目是做什么的
+  description: 'Ant Design 的 Vue 企业级组件库实现',
+
+  // 图标：本地图标名（app/assets/icon 下的 svg，不含 .svg 后缀）
+  // 或 iconify 图标名（如 'logos:vue'），无图标时传空字符串
+  icon: 'icon:ant-design-vue',
+
+  // 项目分类：'ui' | 'hooks' | 'component' | 'admin' | 'uniapp' 等
+  category: 'ui',
+
+  // 项目类型列表，如 'ui-library'、'composable-library' 等
+  types: ['ui-library'],
+
+  // 可选：标签，用于站点内筛选和搜索
+  tags: ['ui', 'ant-design'],
+
+  // 数据源，用于脚本拉取 Stars / 下载量等统计数据
+  // github 使用 'owner/repo' 格式，npm 直接填包名
+  source: {
+    github: 'vueComponent/ant-design-vue',
+    npm: 'ant-design-vue',
+  },
+
+  // 可选：对外展示的链接
+  links: {
+    github: 'https://github.com/vueComponent/ant-design-vue',
+    npm: 'https://www.npmjs.com/package/ant-design-vue',
+    website: 'https://antdv.com',
+  },
+
+  // 统计数据（Stars、下载量）由定时任务自动同步，无需手动维护
+  stats: {
+    stars: 21641,
+    downloads: {
+      monthly: 942627,
+      weekly: 168488,
+    },
+  },
+})
+```
+
+注意事项：
+
+- `name`、`source.github`、`source.npm` 必须与真实的仓库名 / 包名一致，数据同步脚本依赖这些字段拉取信息。
+- `stats` 由定时任务自动更新，**不需要手动维护**；也可以在本地运行 `pnpm sync:npm-git-data` 手动刷新。
+- 需要新增字段时，请先修改 `packages/schema/` 中的类型定义。
+
+## 提交 PR 规范（Conventional Commits）
+
+提交 PR 时请严格遵循 [Conventional Commits](https://www.conventionalcommits.org/zh-hans/) 规范。仓库已启用 `verify-git-commit` 校验提交信息，不符合格式的提交会被拒绝：
+
+```
+type(scope): subject
+```
+
+- **type**：`feat`、`fix`、`docs`、`style`、`refactor`、`perf`、`test`、`build`、`ci`、`chore`、`revert`
+- **scope**（可选）：改动所属模块，如 `db`、`data-ui`、`data-nuxt`、`schema`、`shared`、`ui`、`deps`
+- **subject**：简短描述，小写开头，结尾不加句号
+
+示例：
+
+```
+feat(data-ui): add ant-design-vue entry
+fix(db): handle missing tags in index db generation
+chore(deps): update nuxt to latest
+```
+
+提交流程：
+
+1. 从最新的 `master` 创建功能分支：
+
+   ```bash
+   git checkout -b feat/my-feature
+   ```
+
+2. 提交前确保以下检查通过：
+
+   ```bash
+   pnpm lint
+   pnpm typecheck
+   ```
+
+3. 向 `master` 提交 PR，在描述中说明改动内容和动机；数据类 PR 请注明影响的条目。
+
+## 写在最后
+
+**不要怕犯错误，勇敢地去做。**
+
+每一个成熟的仓库都是从无数次的试错中成长起来的。提交错了可以改，PR 写得不完善会有热心的维护者帮你 review，没有人会因为你的一次失误而责怪你——这正是开源世界最温柔的地方。
+
+开源世界欢迎大家，Vue.js 社区期待各位的发展壮大。期待在 Contributor 列表中看到你的名字！🚀


### PR DESCRIPTION
### Background

The contributing guide previously existed as a single version, and its structure no longer reflected how data maintenance actually works (e.g. which `packages/data-*` directories accept manual edits). This PR introduces a bilingual setup: an English `CONTRIBUTING.md` as the default guide plus a Chinese `CONTRIBUTING_CN.md` with identical content, so both audiences read the same up-to-date conventions.

### Changes

- Rewrote `CONTRIBUTING.md` in English with a clearer outline:
  - Hard requirements: Node.js >= 22 and pnpm > v11.x
  - Three-step quick start: clone -> install dependencies -> `pnpm run docs:dev`
  - Project structure overview marking which data packages are maintainable
  - Data maintenance policy: only `packages/data-{ui,component,hooks,admin,uniapp}` accept manual edits; `data-nuxt` / `data-plugins` are auto-synced by scheduled scripts, and fixes there should only touch the `scripts/` of those subprojects
  - A fully commented `defineProjectMeta` example based on the real `@vuejs-community/schema` fields
  - Conventional Commits PR guidelines and an encouraging closing note
- Added `CONTRIBUTING_CN.md` with the identical content in Chinese.

### Related Issues

None

### Verification

- Docs-only change; content cross-checked against the actual repository structure and the `CommunityProject` type definitions in `packages/schema`.
- `eslint` passes on both markdown files (also enforced on staged files via the pre-commit `lint-staged` hook).