### PR TITLE
feat(api): paginate project results

### DIFF
--- a/server/api/projects.get.ts
+++ b/server/api/projects.get.ts
@@ -4,6 +4,8 @@ const numericFilterColumns = [
   'stars',
 ] as const
 
+const pageSize = 12
+
 function readTextFilter(value: unknown, name: string): string | undefined {
   if (value === undefined)
     return undefined
@@ -43,6 +45,16 @@ function readNumberFilter(value: unknown, name: string): number | undefined {
 
 export default defineEventHandler(async (event): Promise<ProjectRecord[]> => {
   const query = getQuery(event)
+  const page = readNumberFilter(query.more, 'more') ?? 0
+  const offset = page * pageSize
+
+  if (!Number.isSafeInteger(offset)) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'more is too large',
+    })
+  }
+
   const filters: ProjectFilters = {
     category: readTextFilter(query.category, 'category'),
     source: readTextFilter(query.source, 'source'),
@@ -95,7 +107,9 @@ export default defineEventHandler(async (event): Promise<ProjectRecord[]> => {
       downloads_monthly DESC,
       downloads_weekly DESC,
       name COLLATE NOCASE ASC
+    LIMIT ?
+    OFFSET ?
   `)
 
-  return await statement.all(...parameters) as ProjectRecord[]
+  return await statement.all(...parameters, pageSize, offset) as ProjectRecord[]
 })


### PR DESCRIPTION
### Background

The projects endpoint currently returns all matching records in a single response. Add pagination to keep responses bounded and support incremental loading.

### Changes

- Limit each response to 12 projects.
- Accept a non-negative `more` parameter as the zero-based page index.
- Preserve the existing filtering and sorting behavior.
- Reject invalid or excessively large pagination values with a 400 response.

### Related Issues

None

### Verification

- Manually verified the pagination behavior.
- ESLint completed successfully through the pre-commit hook.