### PR TITLE
docs(schema): document community project fields

### DIFF
--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -91,7 +91,9 @@ export interface Stats {
 }
 
 export interface CommunityProject {
+  // Project name, must match the real package / repository name
   name: string
+  // One-sentence description of what the project does
   description: string
 
   /**
@@ -99,23 +101,32 @@ export interface CommunityProject {
    * or https://icon-sets.iconify.design/ icon name,
    * or an empty string when no icon is present
    */
+  // Icon: local icon name (svg under app/assets/icon, without the .svg suffix)
+  // or an iconify icon name (e.g. 'logos:vue'); pass an empty string if there is none
   icon: string
 
+  // Project category: 'ui' | 'hooks' | 'component' | 'admin' | 'uniapp' etc.
   category: ProjectCategory
 
+  // Project type list, e.g. 'ui-library', 'composable-library', etc.
   types: string[]
 
+  // Optional: tags for filtering and searching within the site
   tags?: string[]
 
   filter?: string[]
 
+  // Data source, used by scripts to fetch stats such as Stars / downloads
+  // github uses the 'owner/repo' format; npm takes the package name directly
   links?: {
     github?: string
     npm?: string
     website?: string
   }
 
+  // Optional: links shown publicly
   source?: Source
 
+  // Stats (Stars, downloads) are synced automatically by scheduled jobs, no manual maintenance needed
   stats?: Stats
 }


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None.

### 💡 Background and Solution

The `CommunityProject` interface lacked concise guidance for several project metadata fields.

This change adds inline documentation for project names, descriptions, icons, categories, types, tags, data-source links, public links, and automatically synchronized statistics. It does not change runtime behavior or the schema's type structure.

### 📝 Change Log

- Added inline documentation for `CommunityProject` metadata fields.
- Clarified supported icon formats and GitHub/npm link values.
- Clarified that project statistics are synchronized automatically.
