### PR TITLE
feat(api): return project pagination metadata

### DIFF
--- a/server/api/projects.get.ts
+++ b/server/api/projects.get.ts
@@ -43,7 +43,7 @@ function readNumberFilter(value: unknown, name: string): number | undefined {
   return parsedValue
 }
 
-export default defineEventHandler(async (event): Promise<ProjectRecord[]> => {
+export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
   const query = getQuery(event)
   const page = readNumberFilter(query.more, 'more') ?? 0
   const offset = page * pageSize
@@ -87,7 +87,7 @@ export default defineEventHandler(async (event): Promise<ProjectRecord[]> => {
   const whereClause = conditions.length > 0
     ? `WHERE ${conditions.join(' AND ')}`
     : ''
-  const statement = event.context.database.prepare(`
+  const dataStatement = event.context.database.prepare(`
     SELECT
       name,
       description,
@@ -111,5 +111,21 @@ export default defineEventHandler(async (event): Promise<ProjectRecord[]> => {
     OFFSET ?
   `)
 
-  return await statement.all(...parameters, pageSize, offset) as ProjectRecord[]
+  const totalStatement = event.context.database.prepare(`
+    SELECT COUNT(*) AS total
+    FROM projects
+    ${whereClause}
+  `)
+
+  const [data, totalRow] = await Promise.all([
+    dataStatement.all(...parameters, pageSize, offset) as Promise<ProjectRecord[]>,
+    totalStatement.get(...parameters) as Promise<{ total: number }>,
+  ])
+  const total = totalRow.total
+
+  return {
+    data,
+    total,
+    more: offset + data.length < total,
+  }
 })

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -14,6 +14,12 @@ export interface ProjectRecord {
   stars: number
 }
 
+export interface ProjectsResponse {
+  data: ProjectRecord[]
+  total: number
+  more: boolean
+}
+
 export interface CategoryCount {
   category: string
   count: number


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The projects API previously returned only the current page of up to 12 project records, so consumers could not determine the total number of matching projects or whether additional pages were available.

The response now contains:

- `data`: The project records for the requested page.
- `total`: The total number of projects matching the current filters.
- `more`: Whether additional project records are available after the current page.

The existing `more` query parameter continues to represent the zero-based page index.

### 📝 Change Log

Changed the `/api/projects` response from a project array to an object containing `data`, `total`, and `more`.
