### PR TITLE
refactor(api): validate projects query with zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "turbo": "^2.10.12",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3",
-    "verify-git-commit": "^0.0.1"
+    "verify-git-commit": "^0.0.1",
+    "zod": "^4.5.4"
   },
   "simple-git-hooks": {
     "pre-commit": "npx lint-staged",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -141,6 +141,9 @@ importers:
       verify-git-commit:
         specifier: ^0.0.1
         version: 0.0.1
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
 
   packages/data-admin:
     devDependencies:
@@ -6090,6 +6093,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -12522,5 +12528,7 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.5.4: {}
 
   zwitch@2.0.4: {}

--- a/server/api/projects.get.ts
+++ b/server/api/projects.get.ts
@@ -1,3 +1,5 @@
+import * as z from 'zod'
+
 const numericFilterColumns = [
   'downloads_monthly',
   'downloads_weekly',
@@ -6,79 +8,45 @@ const numericFilterColumns = [
 
 const pageSize = 12
 
-function readTextFilter(value: unknown, name: string): string | undefined {
-  if (value === undefined)
-    return undefined
-
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw createError({
-      statusCode: 400,
-      statusMessage: `${name} must be a non-empty string`,
-    })
-  }
-
-  return value.trim()
-}
-
-function readNumberFilter(value: unknown, name: string): number | undefined {
-  if (value === undefined)
-    return undefined
-
-  if (typeof value !== 'string' || value.trim() === '') {
-    throw createError({
-      statusCode: 400,
-      statusMessage: `${name} must be a non-negative integer`,
-    })
-  }
-
-  const parsedValue = Number(value)
-
-  if (!Number.isSafeInteger(parsedValue) || parsedValue < 0) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: `${name} must be a non-negative integer`,
-    })
-  }
-
-  return parsedValue
-}
+const querySchema = z.object({
+  more: z.coerce.number().int().min(0).max(100).default(0),
+  category: z.string().trim().optional().default(''),
+  source: z.string().trim().optional().default(''),
+  downloads_monthly: z.coerce.number().int().min(0).default(0),
+  downloads_weekly: z.coerce.number().int().min(0).default(0),
+  stars: z.coerce.number().int().min(0).optional().default(0),
+})
 
 export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
-  const query = getQuery(event)
-  const page = readNumberFilter(query.more, 'more') ?? 0
+  const query = querySchema.parse(getQuery(event))
+  const page = query.more
   const offset = page * pageSize
 
-  if (!Number.isSafeInteger(offset)) {
-    throw createError({
-      statusCode: 400,
-      statusMessage: 'more is too large',
-    })
+  const filters: ProjectFilters = {
+    category: query.category,
+    source: query.source,
+    downloads_monthly: query.downloads_monthly,
+    downloads_weekly: query.downloads_weekly,
+    stars: query.stars,
   }
 
-  const filters: ProjectFilters = {
-    category: readTextFilter(query.category, 'category'),
-    source: readTextFilter(query.source, 'source'),
-    downloads_monthly: readNumberFilter(query.downloads_monthly, 'downloads_monthly'),
-    downloads_weekly: readNumberFilter(query.downloads_weekly, 'downloads_weekly'),
-    stars: readNumberFilter(query.stars, 'stars'),
-  }
   const conditions: string[] = []
   const parameters: Array<number | string> = []
 
-  if (filters.category !== undefined) {
+  if (filters.category) {
     conditions.push('category = ?')
     parameters.push(filters.category)
   }
 
-  if (filters.source !== undefined) {
+  if (filters.source) {
     conditions.push('source = ?')
     parameters.push(filters.source)
   }
 
   for (const column of numericFilterColumns) {
-    const value = filters[column]
+    const value = filters[column]!
 
-    if (value !== undefined) {
+    if (value) {
       conditions.push(`${column} >= ?`)
       parameters.push(value)
     }
@@ -87,6 +55,7 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
   const whereClause = conditions.length > 0
     ? `WHERE ${conditions.join(' AND ')}`
     : ''
+
   const dataStatement = event.context.database.prepare(`
     SELECT
       name,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The `/api/projects` endpoint previously validated query parameters with two hand-written helpers (`readTextFilter` / `readNumberFilter`), which duplicated parsing logic for every field and rejected invalid input one field at a time.

This PR replaces the manual validation with a single zod schema:

- `more`, `downloads_monthly`, `downloads_weekly`, `stars` are coerced to non-negative integers, with `more` additionally capped at 100.
- `category` and `source` are optional trimmed strings; a missing or empty value means "no filter", preserving the previous behavior.
- The now-unused helper functions are removed.

External impact: invalid numeric query values now fail zod validation instead of returning the previous 400 errors with custom messages. Valid requests behave the same as before.

### 📝 Change Log

- The `/api/projects` endpoint validates query parameters through a zod schema; `zod` is added as a dependency.
- Invalid query values now reject with a validation error instead of field-specific 400 messages.
