### PR TITLE
feat(nuxt): auto-import shared constants

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -27,6 +27,12 @@ export default defineNuxtConfig({
     ],
   },
 
+  imports: {
+    dirs: [
+      'shared/constants',
+    ],
+  },
+
   app: {
     head: {
       title: 'Vue Community — Discover the Vue Ecosystem',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

- Shared constants now live in `shared/constants`, but consumers need explicit import paths for each file.
- Register the directory in the Nuxt `imports.dirs` option so constants exported from `shared/constants` (e.g. `projectCategory`) become auto-imports, consistent with the existing `#shared` alias setup.

```ts
imports: {
  dirs: [
    'shared/constants',
  ],
},
```

### 📝 Change Log

- Constants exported from `shared/constants` are now available as Nuxt auto-imports across the app without explicit imports.
