### PR TITLE
fix(app): use NuxtLink for header nav and correct nav labels

### DIFF
--- a/app/components/SiteHeader.vue
+++ b/app/components/SiteHeader.vue
@@ -20,7 +20,9 @@
           <NavigationMenuList>
             <NavigationMenuItem v-for="nav in navs" :key="nav.label">
               <NavigationMenuLink as-child>
-                <a class="text-foreground text-sm font-medium capitalize" href="/">{{ nav.label }}</a>
+                <NuxtLink class="text-foreground text-sm font-medium capitalize" :to="nav.to">
+                  {{ nav.label }}
+                </NuxtLink>
               </NavigationMenuLink>
             </NavigationMenuItem>
           </NavigationMenuList>
@@ -56,7 +58,7 @@ const navs = [
     to: '/ui',
   },
   {
-    label: 'component',
+    label: 'components',
     to: '/component',
   },
   {
@@ -64,12 +66,12 @@ const navs = [
     to: '/hooks',
   },
   {
-    label: 'plugin',
+    label: 'plugins',
     to: '/plugin',
   },
   {
-    label: 'module',
-    to: '/module',
+    label: 'modules',
+    to: '/nuxt',
   },
   {
     label: 'admin',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The header navigation items were rendered as plain `<a href="/">` tags, so every nav entry redirected back to the homepage instead of its target section. The nav labels were also inconsistent with the site sections ("component", "plugin", "module" vs. plural section names), and the modules entry pointed to a non-existent `/module` route.

Solution: render nav items with `NuxtLink :to="nav.to"` so client-side navigation works, rename labels to plural form (`components`, `plugins`, `modules`), and point the modules entry to the real `/nuxt` route.

### 📝 Change Log

- Header navigation now navigates to each section's real route (`/ui`, `/component`, `/hooks`, `/plugin`, `/nuxt`, `/admin`) instead of the homepage.
- Renamed nav labels to plural form and fixed the modules entry to use `/nuxt`.
