### PR TITLE
refactor: rename projectCategory to projectCategories and fix shared constants auto-import

### DIFF
--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -44,7 +44,6 @@
 
 <script lang="ts" setup>
 import type { ProjectCategory } from '~~/packages/schema/src/types.ts'
-import { projectCategory } from '#shared/constants/category.ts'
 import { cn } from '~/lib/utils.ts'
 
 definePageMeta({
@@ -54,7 +53,7 @@ definePageMeta({
 const route = useRoute()
 const category = computed(() => route.params.category as ProjectCategory)
 
-if (!projectCategory.includes(category.value)) {
+if (!projectCategories.includes(category.value)) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -29,7 +29,7 @@ export default defineNuxtConfig({
 
   imports: {
     dirs: [
-      'shared/constants',
+      '../shared/constants',
     ],
   },
 

--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -1,4 +1,4 @@
-export const projectCategory = [
+export const projectCategories = [
   'ui',
   'hooks',
   'nuxt',


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The constant exported from `shared/constants/category.ts` was named `projectCategory` even though it holds a list of categories, and `imports.dirs` in `nuxt.config.ts` pointed to `shared/constants`, which does not resolve correctly from the app directory. As a result, shared constants were not auto-imported and had to be imported manually.

This PR:
- Renames `projectCategory` to `projectCategories` to reflect that it is a list, and updates its usages.
- Fixes `imports.dirs` in `nuxt.config.ts` to `../shared/constants` so shared constants are auto-imported correctly.
- Removes the now-redundant manual import in `app/pages/[category].vue`.

### 📝 Change Log

- Renamed the exported constant `projectCategory` to `projectCategories` in `shared/constants/category.ts`; update any direct imports if you use it locally.
- Shared constants under `shared/constants` are now auto-imported in the Nuxt app via the corrected `imports.dirs` configuration.
