### PR TITLE
fix: use more descriptive category labels

### DIFF
--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -60,7 +60,7 @@ if (!projectCategories.includes(category.value)) {
 const categoryLabels = {
   ui: 'UI Libraries',
   hooks: 'Hooks',
-  nuxt: 'Nuxt',
+  nuxt: 'Nuxt Modules',
   plugin: 'Plugin',
   starter: 'Starter',
   utilities: 'Utilities',
@@ -68,7 +68,7 @@ const categoryLabels = {
   tool: 'Tool',
   component: 'Component',
   uniapp: 'UniApp',
-  admin: 'Admin',
+  admin: 'Admin Template',
 } as const satisfies Record<ProjectCategory, string>
 
 const title = computed(() => categoryLabels[category.value])


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The category page displayed generic labels for two categories: `Nuxt` and `Admin`. These names did not clearly describe what kind of projects are listed under them.

This PR updates the displayed labels to `Nuxt Modules` and `Admin Template`. The underlying route values (`nuxt`, `admin`) and data sources are unchanged; only the display text is updated.

### 📝 Change Log

- Category page titles now show `Nuxt Modules` and `Admin Template` instead of `Nuxt` and `Admin`.
