### PR TITLE
refactor: return category counts as a keyed map from stats endpoint

### DIFF
--- a/server/api/projects/stats.get.ts
+++ b/server/api/projects/stats.get.ts
@@ -1,4 +1,4 @@
-export default defineEventHandler(async (event): Promise<CategoryCount[]> => {
+export default defineEventHandler(async (event): Promise<CategoryCounts> => {
   const statement = event.context.database.prepare(`
     SELECT
       category,
@@ -10,5 +10,9 @@ export default defineEventHandler(async (event): Promise<CategoryCount[]> => {
       category COLLATE NOCASE ASC
   `)
 
-  return await statement.all() as CategoryCount[]
+  const categoryCounts = await statement.all() as CategoryCount[]
+
+  return Object.fromEntries(
+    categoryCounts.map(({ category, count }) => [category, count]),
+  )
 })

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -25,6 +25,8 @@ export interface CategoryCount {
   count: number
 }
 
+export type CategoryCounts = Record<string, number>
+
 export interface ProjectFilters {
   category?: string
   source?: string


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The `GET /api/projects/stats` endpoint previously returned an array of `{ category, count }` objects, forcing consumers to iterate over the array and build their own index on every call. Since category names are unique in the aggregation result, the endpoint now returns a plain object keyed by category name:

```json
{ "component": 42, "ui": 17 }
```

Changes:

- Added a `CategoryCounts` type (`Record<string, number>`) in `shared/types/project.ts`, alongside the existing `CategoryCount` interface which is still used internally for the SQL result rows.
- Updated `server/api/projects/stats.get.ts` to build the keyed map with `Object.fromEntries` and to declare `CategoryCounts` as the handler return type.

There are no in-repo consumers of this endpoint yet, so no other code required updates.

### 📝 Change Log

- **Changed**: The `GET /api/projects/stats` response shape changed from `CategoryCount[]` (`{ category, count }[]`) to `CategoryCounts` (`Record<string, number>`). Any external consumers must read counts by category key (e.g. `counts.component`) instead of scanning array entries.
