### PR TITLE
feat: add llms.txt endpoint for LLM-friendly project discovery

### DIFF
--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -53,7 +53,7 @@ definePageMeta({
 const route = useRoute()
 const category = computed(() => route.params.category as ProjectCategory)
 
-if (!projectCategories.includes(category.value)) {
+if (!projectCategoryIds.includes(category.value)) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 

--- a/modules/llms/index.ts
+++ b/modules/llms/index.ts
@@ -1,0 +1,37 @@
+import type { LLmsModuleOptions } from './runtime/types.ts'
+import { addServerHandler, createResolver, defineNuxtModule } from 'nuxt/kit'
+import { SITE_DESCRIPTION, SITE_TITLE, SITE_URL } from '../../shared/constants/seo.meta.ts'
+
+export default defineNuxtModule<LLmsModuleOptions>({
+  meta: {
+    name: 'vue-community-llms',
+    configKey: 'llms',
+    compatibility: {
+      nuxt: '>=4.0.0',
+    },
+  },
+
+  defaults: {
+    siteName: SITE_TITLE,
+    siteUrl: SITE_URL,
+    description: SITE_DESCRIPTION,
+    cacheMaxAge: 3600,
+  },
+
+  setup(options, nuxt) {
+    const resolver = createResolver(import.meta.url)
+
+    nuxt.options.runtimeConfig.llms = {
+      siteName: options.siteName,
+      siteUrl: options.siteUrl,
+      description: options.description,
+      cacheMaxAge: options.cacheMaxAge,
+    }
+
+    addServerHandler({
+      route: '/llms.txt',
+      method: 'get',
+      handler: resolver.resolve('./runtime/server/handlers/llms'),
+    })
+  },
+})

--- a/modules/llms/runtime/server/handlers/llms.ts
+++ b/modules/llms/runtime/server/handlers/llms.ts
@@ -1,0 +1,52 @@
+import type { LLmsModuleOptions } from '../../types'
+import { defineEventHandler, setResponseHeader, setResponseStatus } from 'h3'
+import { useRuntimeConfig } from '#imports'
+import { generateLLms } from '../utils/generate-llms'
+import { queryLlmsProjects } from '../utils/query-projects'
+
+interface CachedDocument {
+  expiresAt: number
+  value: string
+}
+
+let cachedDocument: CachedDocument | undefined
+
+export default defineEventHandler(async (event) => {
+  setResponseHeader(event, 'content-type', 'text/plain; charset=utf-8')
+  setResponseHeader(event, 'x-content-type-options', 'nosniff')
+
+  const runtimeConfig = useRuntimeConfig(event)
+  const config = runtimeConfig.llms as LLmsModuleOptions
+  const cacheEnabled = config.cacheMaxAge > 0 && Boolean(config.siteUrl)
+
+  if (cacheEnabled)
+    setResponseHeader(event, 'cache-control', `public, max-age=0, s-maxage=${config.cacheMaxAge}`)
+  else
+    setResponseHeader(event, 'cache-control', 'no-store')
+
+  try {
+    const now = Date.now()
+    if (cacheEnabled && cachedDocument?.expiresAt && cachedDocument.expiresAt > now)
+      return event.method === 'HEAD' ? '' : cachedDocument.value
+
+    const projects = await queryLlmsProjects(event.context.database)
+    const document = generateLLms(projects, {
+      siteName: config.siteName,
+      siteUrl: config.siteUrl,
+      description: config.description,
+    })
+
+    if (cacheEnabled) {
+      cachedDocument = {
+        expiresAt: now + config.cacheMaxAge * 1000,
+        value: document,
+      }
+    }
+
+    return event.method === 'HEAD' ? '' : document
+  }
+  catch (error) {
+    setResponseStatus(event, 500, 'Internal Server Error')
+    return event.method === 'HEAD' ? '' : 'Unable to generate llms.txt.\n'
+  }
+})

--- a/modules/llms/runtime/server/utils/generate-llms.ts
+++ b/modules/llms/runtime/server/utils/generate-llms.ts
@@ -1,0 +1,86 @@
+import type { LLmsModuleOptions } from '~~/modules/llms/runtime/types.ts'
+import { projectCategoryMetadata } from '#shared/constants/category.ts'
+import { formatCount } from '#shared/utils/format.ts'
+
+const categoryLabels = new Map(projectCategoryMetadata.map(category => [category.id, category.label]))
+
+function categoryLabel(category: string): string {
+  const knownLabel = categoryLabels.get(category)
+  if (knownLabel)
+    return knownLabel
+
+  return category
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map(part => `${part.charAt(0).toUpperCase()}${part.slice(1)}`)
+    .join(' ')
+}
+
+function compareProjects(left: ProjectRecord, right: ProjectRecord): number {
+  return right.stars - left.stars
+    || right.downloads_monthly - left.downloads_monthly
+    || right.downloads_weekly - left.downloads_weekly
+    || left.name.localeCompare(right.name, 'en', { sensitivity: 'base' })
+}
+
+function createProjectLine(project: ProjectRecord): string {
+  const links = [
+    { label: 'Website', url: project.website },
+    { label: 'GitHub', url: project.github },
+    { label: 'npm', url: project.npm },
+  ].filter(link => link.url)
+
+  const projectReference = links[0] ? `[${project.name}](${links[0].url})` : project.name
+  const details = project.description ? `${projectReference}: ${project.description}` : projectReference
+
+  const secondaryLinks = links
+    .slice(1)
+    .map(link => `[${link.label}](${link.url})`)
+
+  const stats = [
+    project.stars > 0 ? `${formatCount(project.stars)} GitHub stars` : '',
+    project.downloads_monthly > 0 ? `${formatCount(project.downloads_monthly)} monthly npm downloads` : '',
+  ].filter(Boolean)
+
+  const metadata = [...secondaryLinks, ...stats]
+
+  return `- ${details}${metadata.length > 0 ? ` — ${metadata.join(' · ')}` : ''}`
+}
+
+function compareCategories(left: string, right: string): number {
+  const leftIndex = projectCategoryMetadata.findIndex(category => category.id === left)
+  const rightIndex = projectCategoryMetadata.findIndex(category => category.id === right)
+  const normalizedLeftIndex = leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex
+  const normalizedRightIndex = rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex
+
+  return normalizedLeftIndex - normalizedRightIndex || left.localeCompare(right, 'en')
+}
+
+export function generateLLms(projects: ProjectRecord[], options: Omit<LLmsModuleOptions, 'cacheMaxAge'>): string {
+  const projectsByCategory = Map.groupBy(projects, project => project.category)
+  const categoryIds = [...projectsByCategory.keys()].sort(compareCategories)
+  const lines = [
+    `# ${options.siteName}`,
+    '',
+    `> ${options.description}`,
+    '',
+    '## Main Pages',
+    '',
+    `- [Home](${options.siteUrl})`,
+    ...categoryIds.map((category) => {
+      const categoryProjects = projectsByCategory.get(category) ?? []
+      const categoryUrl = new URL(encodeURIComponent(category), options.siteUrl).toString()
+      const projectLabel = categoryProjects.length === 1 ? 'project' : 'projects'
+      return `- [${categoryLabel(category)}](${categoryUrl}): ${categoryProjects.length.toLocaleString('en-US')} ${projectLabel}`
+    }),
+  ]
+
+  for (const category of categoryIds) {
+    const categoryProjects = [...(projectsByCategory.get(category) ?? [])].sort(compareProjects)
+
+    lines.push('', `## ${categoryLabel(category)}`, '')
+    lines.push(...categoryProjects.map(project => createProjectLine(project)))
+  }
+
+  return `${lines.join('\n')}\n`
+}

--- a/modules/llms/runtime/server/utils/query-projects.ts
+++ b/modules/llms/runtime/server/utils/query-projects.ts
@@ -1,0 +1,20 @@
+import type { Database } from 'db0'
+
+export async function queryLlmsProjects(database: Database): Promise<ProjectRecord[]> {
+  const statement = database.prepare(`
+    SELECT
+      name,
+      description,
+      category,
+      source,
+      github,
+      npm,
+      website,
+      downloads_monthly,
+      downloads_weekly,
+      stars
+    FROM projects
+  `)
+
+  return await statement.all() as ProjectRecord[]
+}

--- a/modules/llms/runtime/types.ts
+++ b/modules/llms/runtime/types.ts
@@ -1,0 +1,6 @@
+export interface LLmsModuleOptions {
+  siteName: string
+  siteUrl: string
+  description: string
+  cacheMaxAge: number
+}

--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -1,13 +1,20 @@
-export const projectCategories = [
-  'ui',
-  'hooks',
-  'nuxt',
-  'plugin',
-  'starter',
-  'utilities',
-  'library',
-  'tool',
-  'component',
-  'uniapp',
-  'admin',
+export interface CategoryDefinition {
+  id: string
+  label: string
+}
+
+export const projectCategoryMetadata: CategoryDefinition[] = [
+  { id: 'ui', label: 'UI Libraries' },
+  { id: 'component', label: 'Components' },
+  { id: 'hooks', label: 'Hooks and Composables' },
+  { id: 'nuxt', label: 'Nuxt Modules' },
+  { id: 'plugin', label: 'Vite Plugins' },
+  { id: 'starter', label: 'Starters' },
+  { id: 'utilities', label: 'Utilities' },
+  { id: 'library', label: 'Libraries' },
+  { id: 'tool', label: 'Developer Tools' },
+  { id: 'admin', label: 'Admin Templates' },
+  { id: 'uniapp', label: 'UniApp Ecosystem' },
 ]
+
+export const projectCategoryIds = projectCategoryMetadata.map(c => c.id) as string[]

--- a/shared/constants/seo.meta.ts
+++ b/shared/constants/seo.meta.ts
@@ -1,0 +1,3 @@
+export const SITE_TITLE = 'Vuejs Community — Discover the Vue Ecosystem'
+export const SITE_DESCRIPTION = 'Discover Vue libraries, UI components, composables, Nuxt modules, Vite plugins, and developer tools in one open, community-driven ecosystem.'
+export const SITE_URL = 'https://vuejs-community.vercel.app'


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

AI assistants and LLM-based agents increasingly discover sites through a standardized `llms.txt` file at the site root, but this site currently exposes project data only through HTML pages and JSON APIs, which are less suitable for LLM consumption.

This PR adds a local Nuxt module (`modules/llms`, module name `vue-community-llms`) that serves a markdown-formatted `GET /llms.txt` endpoint:

- Generates a document with the site title and description, links to the home page and every category page, followed by all projects grouped by category and sorted by stars, monthly downloads, weekly downloads, and name.
- Projects are rendered as markdown list items containing their description, website/GitHub/npm links, and GitHub star plus monthly download stats.
- Category headings and ordering use the new labeled category metadata, with title-casing fallback for unknown categories.
- The endpoint is configurable through the `llms` config key (`siteName`, `siteUrl`, `description`, `cacheMaxAge`), defaulting to the new shared SEO constants, and caches the generated document in memory behind `Cache-Control: public, max-age=0, s-maxage=<ttl>` headers.
- Responds correctly to `HEAD` requests and returns a plain-text 500 error page if generation fails.

To support this, `shared/constants/category.ts` was refactored from the plain `projectCategories` string array into `projectCategoryMetadata` (objects with `id` and human-readable `label`) plus a derived `projectCategoryIds` list; the category page validation now checks against `projectCategoryIds`.

### 📝 Change Log

- Added a `/llms.txt` endpoint that exposes the full project catalog as an LLM-friendly markdown document, grouped by labeled categories with per-project links and stats.
- Categories now carry human-readable labels via `projectCategoryMetadata`; the previous `projectCategories` array is replaced by the derived `projectCategoryIds` list used for category route validation.
