### PR TITLE
refactor: use shared category metadata for category page labels

### DIFF
--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -57,21 +57,7 @@ if (!projectCategoryIds.includes(category.value)) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const categoryLabels = {
-  ui: 'UI Libraries',
-  hooks: 'Hooks',
-  nuxt: 'Nuxt Modules',
-  plugin: 'Plugin',
-  starter: 'Starter',
-  utilities: 'Utilities',
-  library: 'Library',
-  tool: 'Tool',
-  component: 'Component',
-  uniapp: 'UniApp',
-  admin: 'Admin Template',
-} as const satisfies Record<ProjectCategory, string>
-
-const title = computed(() => categoryLabels[category.value])
+const title = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value)?.label)
 
 const {
   projects,

--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -1,5 +1,7 @@
+import type { ProjectCategory } from '~~/packages/schema/src/types.ts'
+
 export interface CategoryDefinition {
-  id: string
+  id: ProjectCategory
   label: string
 }
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [x] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The category page (`app/pages/[category].vue`) maintained its own local `categoryLabels` map, duplicating the labels already defined in `shared/constants/category.ts` (`projectCategoryMetadata`). This duplication risked the page labels drifting out of sync with the shared single source of truth.

Solution:

- Remove the local `categoryLabels` map and derive the page title from the shared, auto-imported `projectCategoryMetadata` constant.
- Tighten `CategoryDefinition.id` from `string` to the `ProjectCategory` type, so category IDs are validated by the compiler at the definition site.

The page titles are now consistent with the richer shared labels (e.g. `Hooks and Composables`, `Developer Tools`) instead of the terser duplicated ones (`Hooks`, `Tool`).

### 📝 Change Log

- **Changed**: The category page now shows the descriptive labels from the shared `projectCategoryMetadata` constant instead of the duplicated local map.
- **Changed**: `CategoryDefinition.id` is typed as `ProjectCategory` instead of `string`.
