### PR TITLE
feat: add llms.txt link to site header

### DIFF
--- a/app/components/SiteHeader.vue
+++ b/app/components/SiteHeader.vue
@@ -32,6 +32,12 @@
       <!-- Right -->
       <div class="flex shrink-0 items-center gap-2">
         <Button as-child size="icon-sm" variant="ghost">
+          <NuxtLink to="/llms.txt" target="_blank">
+            <Icon name="bi:robot" />
+          </NuxtLink>
+        </Button>
+
+        <Button as-child size="icon-sm" variant="ghost">
           <NuxtLink :to="app.github" target="_blank">
             <Icon name="codicon:github-alt" />
           </NuxtLink>


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The site serves an `llms.txt` endpoint via the local `llms` Nuxt module, but there is no visible entry point to it anywhere in the UI.

This change adds a ghost icon button to the site header's right-side actions (before the GitHub button). It links to `/llms.txt` and opens it in a new tab, reusing the same button/link styling (`as-child`, `size="icon-sm"`, `variant="ghost"`) as the adjacent GitHub link.

### 📝 Change Log

- Added a header icon button linking to `/llms.txt` (opens in a new tab).
