### PR TITLE
ci: rename sync metrics workflow and reorder data sync steps

### DIFF
--- a/.github/workflows/sync-and-generate-data.yml
+++ b/.github/workflows/sync-and-generate-data.yml
@@ -1,4 +1,4 @@
-name: Sync Data And Generate data
+name: Sync metrics And Generate data
 
 on:
   workflow_dispatch:
@@ -9,11 +9,11 @@ permissions:
   contents: write
 
 concurrency:
-  group: sync-and-regenerate-data
+  group: sync-metrics-and-regenerate-data
   cancel-in-progress: false
 
 jobs:
-  sync-and-regenerate:
+  sync-metrics-and-regenerate-data:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -32,14 +32,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Sync UI Component Hooks stats data
-        run: pnpm run sync:npm-git-data
-
       - name: Sync Vite、Rolldown、Rollup and Unplugin plugins data
         run: pnpm run generate:plugins
 
       - name: Sync Nuxt Modules Data
         run: pnpm run generate:nuxt:modules
+
+      - name: Sync UI Component Hooks stats data
+        run: pnpm run sync:npm-git-data
 
       - name: build sync database
         run: pnpm run generate:db


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The data sync workflow was named "Sync Data And Generate data", and the npm/git stats sync (`sync:npm-git-data`) ran before the plugins and Nuxt modules generators. The stats sync is unrelated to that data, so running it first delayed the generators and made the workflow's purpose unclear.

Changes:

- Rename the workflow to "Sync metrics And Generate data" and align the concurrency group (`sync-metrics-and-regenerate-data`) and job name (`sync-metrics-and-regenerate-data`) with it.
- Move the "Sync UI Component Hooks stats data" step after the plugins and Nuxt modules sync steps, so project data generation is not blocked by the stats sync.

### 📝 Change Log

- The workflow now appears as "Sync metrics And Generate data" in GitHub Actions.
- npm/git stats data sync now runs after the plugins and Nuxt modules data generation within the same workflow run.
