### PR TITLE
ci: rename stats sync step in data sync workflow

### DIFF
--- a/.github/workflows/sync-and-generate-data.yml
+++ b/.github/workflows/sync-and-generate-data.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Sync Nuxt Modules Data
         run: pnpm run generate:nuxt:modules
 
-      - name: Sync UI Component Hooks stats data
+      - name: Sync npm and GitHub stats data
         run: pnpm run sync:npm-git-data
 
       - name: build sync database


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The step running `pnpm run sync:npm-git-data` was named "Sync UI Component Hooks stats data", which no longer matches what the step does: the script syncs npm downloads and GitHub stats for all community data packages, not just UI component hooks.

This PR renames the step to "Sync npm and GitHub stats data" so the workflow log accurately reflects the step's behavior.

### 📝 Change Log

- Renamed the "Sync UI Component Hooks stats data" workflow step to "Sync npm and GitHub stats data" in `sync-and-generate-data.yml`. No functional changes.
