### PR TITLE
feat(data-component): add markstream-vue, vue-paged-media and vuedefer project entries

### DIFF
--- a/packages/data-component/src/markstream-vue.ts
+++ b/packages/data-component/src/markstream-vue.ts
@@ -1,0 +1,28 @@
+import { defineProjectMeta } from '@vuejs-community/schema'
+
+export default defineProjectMeta({
+  name: 'markstream-vue',
+  description: '面向 AI 聊天场景的 Vue 流式 Markdown 渲染器，支持 Mermaid、KaTeX 与代码块',
+  icon: '',
+  category: 'component',
+  types: ['component-library'],
+  tags: ['markdown', 'ai', 'streaming'],
+
+  source: {
+    github: 'Simon-He95/markstream-vue',
+    npm: 'markstream-vue',
+  },
+
+  links: {
+    github: 'https://github.com/Simon-He95/markstream-vue',
+    npm: 'https://www.npmjs.com/package/markstream-vue',
+    website: 'https://markstream.simonhe.me',
+  },
+  stats: {
+    stars: 2996,
+    downloads: {
+      monthly: 125989,
+      weekly: 31688,
+    },
+  },
+})

--- a/packages/data-component/src/vue-paged-media.ts
+++ b/packages/data-component/src/vue-paged-media.ts
@@ -1,0 +1,28 @@
+import { defineProjectMeta } from '@vuejs-community/schema'
+
+export default defineProjectMeta({
+  name: 'vue-paged-media',
+  description: '用于在打印前预览分页媒体布局的 Vue 组件库',
+  icon: '',
+  category: 'component',
+  types: ['component-library'],
+  tags: ['preview', 'print'],
+
+  source: {
+    github: 'pkc918/vue-paged-media',
+    npm: 'vue-paged-media',
+  },
+
+  links: {
+    github: 'https://github.com/pkc918/vue-paged-media',
+    npm: 'https://www.npmjs.com/package/vue-paged-media',
+    website: 'https://pkc918.github.io/vue-paged-media',
+  },
+  stats: {
+    stars: 16,
+    downloads: {
+      monthly: 11,
+      weekly: 0,
+    },
+  },
+})

--- a/packages/data-component/src/vuedefer.ts
+++ b/packages/data-component/src/vuedefer.ts
@@ -1,0 +1,28 @@
+import { defineProjectMeta } from '@vuejs-community/schema'
+
+export default defineProjectMeta({
+  name: 'vuedefer',
+  description: '基于视口挂载并支持冻结更新的 Vue 延迟渲染组件',
+  icon: '',
+  category: 'component',
+  types: ['component-library'],
+  tags: ['lazy-load', 'performance'],
+
+  source: {
+    github: 'Alfred-Skyblue/vuedefer',
+    npm: 'vuedefer',
+  },
+
+  links: {
+    github: 'https://github.com/Alfred-Skyblue/vuedefer',
+    npm: 'https://www.npmjs.com/package/vuedefer',
+    website: 'https://vuedefer.pages.dev',
+  },
+  stats: {
+    stars: 84,
+    downloads: {
+      monthly: 40,
+      weekly: 5,
+    },
+  },
+})


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The community project catalog is missing three Vue component libraries. This PR adds their metadata entries under `packages/data-component/src` using the existing `defineProjectMeta` schema conventions:

- **markstream-vue** — streaming Markdown renderer for AI chat scenarios, with Mermaid, KaTeX, and code block support
- **vue-paged-media** — Vue component library for previewing paged media layouts before printing
- **vuedefer** — Vue deferred-render component that mounts on viewport visibility and supports frozen updates

Each entry declares its GitHub/npm source, so Stars and download stats are synced automatically by scheduled jobs.

### 📝 Change Log

- Added three new component project entries (`markstream-vue`, `vue-paged-media`, `vuedefer`) to the data catalog; they will appear on the site once the database is regenerated by the scheduled sync job.
