### PR TITLE
docs: define icon selection rules in add-project-meta skill

### DIFF
--- a/.agents/skills/add-project-meta/SKILL.md
+++ b/.agents/skills/add-project-meta/SKILL.md
@@ -29,7 +29,13 @@ This skill only applies when creating data files under `src/` of the following 7
 
 ## File Template
 
-The Chinese text in the template are field descriptions; replace them with real values when creating a file. `icon` is required in every file: write the local icon name when an icon exists, otherwise write an empty string. Optional fields without data (`tags`, `filter`, `website`, etc.) may be omitted, but `stats` must be written in full (except for `data-admin`, see the next section).
+The Chinese text in the template are field descriptions; replace them with real values when creating a file. `icon` is required in every file and must be selected in this order:
+
+1. Use the corresponding project icon from [Iconify](https://icon-sets.iconify.design/) when one exists.
+2. If Iconify has no matching icon but the project's official GitHub repository contains an SVG logo, save that SVG as `app/assets/icon/<filename>.svg` and set `icon` to `icon:<filename>` (without the `.svg` extension).
+3. If neither source provides a project logo, use the default icon for the project's category: `hooks` → `dinkie-icons:hook`, `ui` → `ci:main-component`, `component` → `icon-park-outline:components`, `nuxt` → `lineicons:nuxt`, `plugin` → `lucide:cable`, `uniapp` → `icon:uniapp`, and `admin` → `lucide:command`.
+
+Never leave `icon` empty. Optional fields without data (`tags`, `filter`, `website`, etc.) may be omitted, but `stats` must be written in full (except for `data-admin`, see the next section).
 
 ```ts
 import { defineProjectMeta } from '@vuejs-community/schema'
@@ -37,7 +43,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 export default defineProjectMeta({
   name: 'Project name',
   description: 'Project description',
-  icon: "Local icon name in the format 'icon:xxx' where app/assets/icon/xxx.svg exists, without the .svg extension; write '' when there is no icon",
+  icon: "Use the Iconify project icon when available; otherwise, if the project's official GitHub repository provides an SVG logo, save it as app/assets/icon/<filename>.svg and use icon:<filename>; if neither is available, use the category default: hooks=dinkie-icons:hook, ui=ci:main-component, component=icon-park-outline:components, nuxt=lineicons:nuxt, plugin=lucide:cable, uniapp=icon:uniapp, admin=lucide:command",
   category: 'The data category this project belongs to; see the ProjectCategory type definition',
 
   types: ['Types the project can be assigned; see the ProjectType type definition'],


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The `add-project-meta` skill previously allowed contributors to leave the
`icon` field empty when no icon was known, which produced entries without
visual identity on the catalog site.

This PR replaces that rule with a strict selection order:

1. Use the matching project icon from Iconify when one exists.
2. Otherwise, save the project's official GitHub SVG logo as
   `app/assets/icon/<filename>.svg` and use `icon:<filename>`.
3. Otherwise, use the category default icon (e.g. `dinkie-icons:hook` for
   hooks, `ci:main-component` for ui, etc.).

Icons must never be left empty. The inline `icon` field description in the
file template was updated accordingly.

### 📝 Change Log

- The `add-project-meta` skill now enforces a mandatory three-step icon
  selection order and no longer permits an empty `icon` value.
