### PR TITLE
feat(api): add project category meta endpoint

### DIFF
--- a/packages/schema/src/index.ts
+++ b/packages/schema/src/index.ts
@@ -1,6 +1,7 @@
 import type { CommunityProject } from './types.ts'
 
-export type { CommunityProject } from './types'
+export { projectCategories } from './types'
+export type { CommunityProject, ProjectCategory } from './types'
 
 export function defineProjectMeta<T extends CommunityProject>(project: T): T {
   return project

--- a/packages/schema/src/types.ts
+++ b/packages/schema/src/types.ts
@@ -1,15 +1,18 @@
-export type ProjectCategory
-  = | 'ui'
-    | 'hooks'
-    | 'nuxt'
-    | 'plugin'
-    | 'starter'
-    | 'utilities'
-    | 'library'
-    | 'tool'
-    | 'component'
-    | 'uniapp'
-    | 'admin'
+export const projectCategories = [
+  'ui',
+  'hooks',
+  'nuxt',
+  'plugin',
+  'starter',
+  'utilities',
+  'library',
+  'tool',
+  'component',
+  'uniapp',
+  'admin',
+] as const
+
+export type ProjectCategory = typeof projectCategories[number]
 
 export interface Source {
   github?: string

--- a/server/api/projects/[category]/meta.get.ts
+++ b/server/api/projects/[category]/meta.get.ts
@@ -1,0 +1,54 @@
+import { projectCategories } from '@vuejs-community/schema'
+import * as z from 'zod'
+
+const categorySchema = z.enum(projectCategories)
+
+interface ProjectMetaStatRow extends ProjectMetaStat {
+  type: ProjectMetaStatType
+}
+
+export default defineEventHandler(async (event): Promise<ProjectMetaStats> => {
+  const categoryResult = categorySchema.safeParse(
+    getRouterParam(event, 'category'),
+  )
+
+  if (!categoryResult.success) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: 'Invalid project category',
+    })
+  }
+
+  const category = categoryResult.data
+
+  const statement = event.context.database.prepare(`
+    SELECT
+      meta.type,
+      meta."values" AS value,
+      COUNT(*) AS count
+    FROM projects AS project
+    INNER JOIN "project-meta" AS meta
+      ON project.name = meta.name
+    WHERE
+      project.category = ?
+      AND meta.type IN ('tags', 'types')
+    GROUP BY
+      meta.type,
+      meta."values"
+    ORDER BY
+      meta.type ASC,
+      count DESC,
+      value COLLATE NOCASE ASC
+  `)
+
+  const rows = await statement.all(category) as ProjectMetaStatRow[]
+  const result: ProjectMetaStats = {
+    tags: [],
+    types: [],
+  }
+
+  for (const { type, value, count } of rows)
+    result[type].push({ value, count })
+
+  return result
+})

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -27,6 +27,15 @@ export interface CategoryCount {
 
 export type CategoryCounts = Record<string, number>
 
+export type ProjectMetaStatType = 'tags' | 'types'
+
+export interface ProjectMetaStat {
+  value: string
+  count: number
+}
+
+export type ProjectMetaStats = Record<ProjectMetaStatType, ProjectMetaStat[]>
+
 export interface ProjectFilters {
   category?: string
   source?: string


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The frontend needs per-category aggregate statistics (tags and types) so it can
render metadata breakdowns for a category without loading the full project list.

- `GET /api/projects/:category/meta` — validates the `category` route param
  against `projectCategories` (zod) and returns aggregated `tags` and `types`
  counts joined from the `project-meta` table (`ProjectMetaStats`).
- `@vuejs-community/schema` now exports `projectCategories` and `ProjectCategory`,
  deriving the category type from a single const so it is reusable by the API layer.
- Added shared types `ProjectMetaStatType`, `ProjectMetaStat`, and
  `ProjectMetaStats` in `shared/types/project.ts`.

### 📝 Change Log

- Added `GET /api/projects/:category/meta` returning aggregated tag/type counts
  for a given category.
- `@vuejs-community/schema` now exports `projectCategories` and `ProjectCategory`.
