### PR TITLE
refactor(app): extract PageHeader component

### DIFF
--- a/app/components/PageHeader.ts
+++ b/app/components/PageHeader.ts
@@ -1,0 +1,22 @@
+import { defineComponent, h } from 'vue'
+
+export default defineComponent({
+  name: 'PageHeader',
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props) {
+    return () => h(
+      'div',
+      { class: 'p-6 border-b md:p-8 lg:p-10' },
+      h(
+        'h1',
+        { class: 'text-2xl font-semibold leading-snug tracking-tighter md:text-3xl lg:text-5xl' },
+        props.title,
+      ),
+    )
+  },
+})

--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -1,10 +1,6 @@
 <template>
   <div class="hidden p-7.5 md:block" />
-  <div class="p-6 md:p-8 lg:p-10 border-b">
-    <h1 class="font-semibold text-2xl leading-snug tracking-tighter md:text-3xl lg:text-5xl">
-      {{ title }}
-    </h1>
-  </div>
+  <PageHeader :title="title" />
 
   <div class="p-6 md:p-8 lg:p-10 border-b hidden">
     <span>search options</span>
@@ -57,7 +53,7 @@ if (!projectCategoryIds.includes(category.value)) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value)?.label)
+const title = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value)?.label ?? '')
 
 const {
   projects,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [x] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The category page (`app/pages/[category].vue`) previously inlined its header markup — a bordered block containing a large title heading. This PR extracts that markup into a reusable `PageHeader` render-function component under `app/components/` and uses it in the category page via `<PageHeader :title="title" />`.

The `title` computed now also falls back to an empty string (`?? ''`) so the component's required `String` prop is always satisfied, even when a category has no matching metadata.

No visual or behavioral changes are intended.

### 📝 Change Log

- Extracted the inline category page header markup into a reusable `PageHeader` component (`app/components/PageHeader.ts`).
- The category page now renders its header through `<PageHeader :title="title" />`, with the title computed falling back to an empty string when category metadata is missing.
