### PR TITLE
fix(app): add missing bottom border to category grid

### DIFF
--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -8,7 +8,8 @@
 
   <div
     :class="cn([
-      'grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+      'relative grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+      'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border',
       '[&>*]:border-b md:max-lg:[&>*:nth-child(odd)]:border-r lg:[&>*:nth-child(3n+2)]:border-x',
     ])"
   >


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🐞 Bug fix
- [ ] 🆕 New feature
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The card grid on category pages (`app/pages/[category].vue`) draws separators through child borders (`border-b` / `border-r` / `border-x`), so the bottom edge of the last row had no divider line, leaving the grid visually open at the bottom.

This adds a full-width bottom rule to the grid container via a non-interactive `after:` pseudo-element (`bg-border`, 1px height), which closes the grid outline on all breakpoints without affecting layout or pointer events.

### 📝 Change Log

- Category page grids now render a bottom divider under the last row of cards on all screen sizes.
