### PR TITLE
feat(app): filter projects by type and tag on category pages

### DIFF
--- a/app/components/project/MetaSection.vue
+++ b/app/components/project/MetaSection.vue
@@ -1,0 +1,43 @@
+<template>
+  <div class="section-padding border-b">
+    <!-- <div class="grid grid-cols-[max-content_1fr] items-start gap-3"> -->
+    <div class="grid grid-cols-[1fr] items-start gap-3">
+      <!--      <div class="flex h-9 items-center text-sm font-medium text-foreground capitalize"> -->
+      <!--        {{ title }} -->
+      <!--      </div> -->
+      <div class="flex flex-wrap items-center gap-3">
+        <Button
+          v-for="(option, index) in options"
+          :key="`${option}-${index}`"
+          :aria-pressed="isMetaSelected(props.type, option)"
+          :class="cn([
+            'bg-transparent shadow-none capitalize',
+            isMetaSelected(props.type, option) ? 'border' : 'border-transparent',
+          ])"
+          variant="outline"
+          @click="toggleMeta(props.type, option)"
+        >
+          {{ option }}
+        </Button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import type { ProjectMetaStatType } from '~~/shared/types/project'
+import { cn } from '~/lib/utils.ts'
+import { useProjectResourceContext } from '.'
+
+defineOptions({
+  name: 'ProjectMetaSection',
+})
+
+const props = defineProps<{
+  type: ProjectMetaStatType
+  title: string
+  options: readonly string[]
+}>()
+
+const { isMetaSelected, toggleMeta } = useProjectResourceContext()
+</script>

--- a/app/components/project/Search.vue
+++ b/app/components/project/Search.vue
@@ -1,0 +1,35 @@
+<template>
+  <ProjectMetaSection
+    v-for="section in sections"
+    :key="section.type"
+    :type="section.type"
+    :title="section.title"
+    :options="section.options"
+  />
+</template>
+
+<script setup lang="ts">
+import { useProjectResourceContext } from '.'
+
+defineOptions({
+  name: 'ProjectSearch',
+})
+
+const metaSectionLabels: Record<ProjectMetaStatType, string> = {
+  types: 'Type',
+  tags: 'Tag',
+}
+
+const metaTypes: ProjectMetaStatType[] = ['types']
+
+const { category } = useProjectResourceContext()
+const { data: meta } = await useProjectMeta(category)
+
+const sections = computed(() => metaTypes
+  .map(type => ({
+    type,
+    title: metaSectionLabels[type],
+    options: meta.value[type].map(({ value }) => value),
+  }))
+  .filter(({ options }) => options.length > 0))
+</script>

--- a/app/components/project/content.vue
+++ b/app/components/project/content.vue
@@ -1,0 +1,50 @@
+<template>
+  <div
+    :class="cn([
+      'relative grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
+      'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border',
+      '[&>*]:border-b md:max-lg:[&>*:nth-child(odd)]:border-r lg:[&>*:nth-child(3n+2)]:border-x',
+    ])"
+  >
+    <CardUiComponent
+      v-for="project in projects"
+      :key="project.name"
+      :project="project"
+    />
+  </div>
+
+  <div v-if="error" class="p-6 md:p-8 lg:p-10 border-b text-center text-destructive">
+    Failed to load projects. Please try again.
+  </div>
+
+  <div v-if="hasMore" class="p-6 md:p-8 lg:p-10 border-b">
+    <div class="flex justify-center items-center">
+      <Button
+        class="rounded-none"
+        variant="outline"
+        :disabled="isLoadingMore"
+        @click="loadMore"
+      >
+        {{ isLoadingMore ? 'Loading...' : 'View More' }}
+        <Icon v-if="!isLoadingMore" name="lucide:arrow-down" />
+      </Button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { cn } from '~/lib/utils'
+import { useProjectResourceContext } from '.'
+
+defineOptions({
+  name: 'ProjectContent',
+})
+
+const {
+  projects,
+  hasMore,
+  isLoadingMore,
+  error,
+  loadMore,
+} = useProjectResourceContext()
+</script>

--- a/app/components/project/index.ts
+++ b/app/components/project/index.ts
@@ -1,0 +1,21 @@
+import type { ProjectCategory } from '@vuejs-community/schema'
+import type { ComputedRef, Ref } from 'vue'
+import type { ProjectMetaStatType, ProjectRecord } from '~~/shared/types/project'
+import { createContext } from 'reka-ui'
+
+export type ProjectMetaSelection = Record<ProjectMetaStatType, string | undefined>
+
+export interface ProjectResourceContext {
+  category: ComputedRef<ProjectCategory>
+  selectedMeta: Readonly<ProjectMetaSelection>
+  projects: Readonly<Ref<readonly ProjectRecord[]>>
+  hasMore: Readonly<Ref<boolean>>
+  isLoadingMore: Readonly<Ref<boolean>>
+  error: Readonly<Ref<unknown>>
+  isMetaSelected: (type: ProjectMetaStatType, value: string) => boolean
+  toggleMeta: (type: ProjectMetaStatType, value: string) => void
+  loadMore: () => Promise<void>
+}
+
+export const [useProjectResourceContext, provideProjectResourceContext]
+  = createContext<ProjectResourceContext>('ProjectResource')

--- a/app/components/project/provider.vue
+++ b/app/components/project/provider.vue
@@ -1,0 +1,60 @@
+<template>
+  <slot />
+</template>
+
+<script setup lang="ts">
+import type { ProjectCategory } from '@vuejs-community/schema'
+import { provideProjectResourceContext } from '.'
+
+defineOptions({
+  name: 'ProjectProvider',
+})
+
+const props = defineProps<{
+  category: ProjectCategory
+}>()
+
+const category = computed(() => props.category)
+const selectedMeta = reactive<Record<ProjectMetaStatType, string | undefined>>({
+  types: undefined,
+  tags: undefined,
+})
+const filters = computed<ProjectFilters>(() => ({
+  category: category.value,
+  type: selectedMeta.types,
+  tag: selectedMeta.tags,
+}))
+
+const {
+  projects,
+  hasMore,
+  isLoadingMore,
+  error,
+  loadMore,
+} = await useProjects(filters)
+
+function isMetaSelected(type: ProjectMetaStatType, value: string) {
+  return selectedMeta[type] === value
+}
+
+function toggleMeta(type: ProjectMetaStatType, value: string) {
+  selectedMeta[type] = isMetaSelected(type, value) ? undefined : value
+}
+
+watch(category, () => {
+  selectedMeta.types = undefined
+  selectedMeta.tags = undefined
+})
+
+provideProjectResourceContext({
+  category,
+  selectedMeta: readonly(selectedMeta),
+  projects,
+  hasMore,
+  isLoadingMore,
+  error,
+  isMetaSelected,
+  toggleMeta,
+  loadMore,
+})
+</script>

--- a/app/composables/useProjectMeta.ts
+++ b/app/composables/useProjectMeta.ts
@@ -1,0 +1,18 @@
+import type { ProjectCategory } from '@vuejs-community/schema'
+import type { MaybeRefOrGetter } from 'vue'
+import type { ProjectMetaStats } from '~~/shared/types/project'
+
+export async function useProjectMeta(category: MaybeRefOrGetter<ProjectCategory>) {
+  const categoryValue = computed(() => toValue(category))
+
+  return useFetch<ProjectMetaStats>(
+    () => `/api/projects/${categoryValue.value}/meta`,
+    {
+      key: computed(() => `project-meta:${categoryValue.value}`),
+      default: () => ({
+        types: [],
+        tags: [],
+      }),
+    },
+  )
+}

--- a/app/composables/useProjects.ts
+++ b/app/composables/useProjects.ts
@@ -1,13 +1,19 @@
+import type { MaybeRefOrGetter } from 'vue'
 import type { ProjectFilters, ProjectRecord, ProjectsResponse } from '~~/shared/types/project'
 
-export async function useProjects(filters: Readonly<ProjectFilters> = {}) {
+export async function useProjects(filters: MaybeRefOrGetter<Readonly<ProjectFilters>> = {}) {
   const page = shallowRef(0)
   const projects = shallowRef<ProjectRecord[]>([])
   const total = shallowRef(0)
   const hasMore = shallowRef(false)
   const isLoadingMore = shallowRef(false)
   const loadMoreError = shallowRef<Error | null>(null)
-  const cacheKey = `projects:${JSON.stringify(Object.entries(filters).sort(([left], [right]) => left.localeCompare(right)))}`
+  const resolvedFilters = computed(() => toValue(filters))
+  const filtersKey = computed(() => JSON.stringify(
+    Object.entries(resolvedFilters.value)
+      .filter(([, value]) => value !== undefined && value !== '')
+      .sort(([left], [right]) => left.localeCompare(right)),
+  ))
 
   const {
     data,
@@ -15,11 +21,11 @@ export async function useProjects(filters: Readonly<ProjectFilters> = {}) {
     refresh,
     status,
   } = await useFetch<ProjectsResponse>('/api/projects', {
-    key: cacheKey,
-    query: {
-      ...filters,
+    key: computed(() => `projects:${filtersKey.value}`),
+    query: computed(() => ({
+      ...resolvedFilters.value,
       more: 0,
-    },
+    })),
   })
 
   function applyFirstPage(response?: ProjectsResponse) {
@@ -29,7 +35,15 @@ export async function useProjects(filters: Readonly<ProjectFilters> = {}) {
     hasMore.value = response?.more ?? false
   }
 
-  applyFirstPage(data.value)
+  watch(data, response => applyFirstPage(response), { immediate: true })
+
+  watch(filtersKey, () => {
+    page.value = 0
+    projects.value = []
+    total.value = 0
+    hasMore.value = false
+    loadMoreError.value = null
+  })
 
   const error = computed(() => initialError.value ?? loadMoreError.value)
 
@@ -42,12 +56,16 @@ export async function useProjects(filters: Readonly<ProjectFilters> = {}) {
 
     try {
       const nextPage = page.value + 1
+      const requestFiltersKey = filtersKey.value
       const response = await $fetch<ProjectsResponse>('/api/projects', {
         query: {
-          ...filters,
+          ...resolvedFilters.value,
           more: nextPage,
         },
       })
+
+      if (requestFiltersKey !== filtersKey.value)
+        return
 
       page.value = nextPage
       projects.value = [...projects.value, ...response.data]

--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -2,46 +2,14 @@
   <div class="hidden p-7.5 md:block" />
   <PageHeader :title="title" />
 
-  <div class="p-6 md:p-8 lg:p-10 border-b hidden">
-    <span>search options</span>
-  </div>
-
-  <div
-    :class="cn([
-      'relative grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3',
-      'after:pointer-events-none after:absolute after:inset-x-0 after:bottom-0 after:h-px after:bg-border',
-      '[&>*]:border-b md:max-lg:[&>*:nth-child(odd)]:border-r lg:[&>*:nth-child(3n+2)]:border-x',
-    ])"
-  >
-    <CardUiComponent
-      v-for="project in projects"
-      :key="project.name"
-      :project="project"
-    />
-  </div>
-
-  <div v-if="error" class="p-6 md:p-8 lg:p-10 border-b text-center text-destructive">
-    Failed to load projects. Please try again.
-  </div>
-
-  <div v-if="hasMore" class="p-6 md:p-8 lg:p-10 border-b">
-    <div class="flex justify-center items-center">
-      <Button
-        class="rounded-none"
-        variant="outline"
-        :disabled="isLoadingMore"
-        @click="loadMore"
-      >
-        {{ isLoadingMore ? 'Loading...' : 'View More' }}
-        <Icon v-if="!isLoadingMore" name="lucide:arrow-down" />
-      </Button>
-    </div>
-  </div>
+  <ProjectProvider :category="category">
+    <ProjectSearch />
+    <ProjectContent />
+  </ProjectProvider>
 </template>
 
 <script lang="ts" setup>
 import type { ProjectCategory } from '~~/packages/schema/src/types.ts'
-import { cn } from '~/lib/utils.ts'
 
 definePageMeta({
   layout: 'content',
@@ -55,12 +23,4 @@ if (!projectCategoryIds.includes(category.value)) {
 }
 
 const title = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value)?.label ?? '')
-
-const {
-  projects,
-  hasMore,
-  isLoadingMore,
-  error,
-  loadMore,
-} = await useProjects({ category: category.value })
 </script>

--- a/server/api/projects.get.ts
+++ b/server/api/projects.get.ts
@@ -12,6 +12,8 @@ const querySchema = z.object({
   more: z.coerce.number().int().min(0).max(100).default(0),
   category: z.string().trim().optional().default(''),
   source: z.string().trim().optional().default(''),
+  type: z.string().trim().optional().default(''),
+  tag: z.string().trim().optional().default(''),
   downloads_monthly: z.coerce.number().int().min(0).default(0),
   downloads_weekly: z.coerce.number().int().min(0).default(0),
   stars: z.coerce.number().int().min(0).optional().default(0),
@@ -25,6 +27,8 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
   const filters: ProjectFilters = {
     category: query.category,
     source: query.source,
+    type: query.type,
+    tag: query.tag,
     downloads_monthly: query.downloads_monthly,
     downloads_weekly: query.downloads_weekly,
     stars: query.stars,
@@ -34,12 +38,12 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
   const parameters: Array<number | string> = []
 
   if (filters.category) {
-    conditions.push('category = ?')
+    conditions.push('project.category = ?')
     parameters.push(filters.category)
   }
 
   if (filters.source) {
-    conditions.push('source = ?')
+    conditions.push('project.source = ?')
     parameters.push(filters.source)
   }
 
@@ -47,8 +51,27 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
     const value = filters[column]!
 
     if (value) {
-      conditions.push(`${column} >= ?`)
+      conditions.push(`project.${column} >= ?`)
       parameters.push(value)
+    }
+  }
+
+  const metaFilters = [
+    { type: 'types', value: filters.type },
+    { type: 'tags', value: filters.tag },
+  ] as const
+
+  for (const metaFilter of metaFilters) {
+    if (metaFilter.value) {
+      conditions.push(`EXISTS (
+        SELECT 1
+        FROM "project-meta" AS meta
+        WHERE
+          meta.name = project.name
+          AND meta.type = ?
+          AND meta."values" = ?
+      )`)
+      parameters.push(metaFilter.type, metaFilter.value)
     }
   }
 
@@ -58,31 +81,31 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
 
   const dataStatement = event.context.database.prepare(`
     SELECT
-      name,
-      description,
-      icon,
-      category,
-      source,
-      github,
-      npm,
-      website,
-      downloads_monthly,
-      downloads_weekly,
-      stars
-    FROM projects
+      project.name,
+      project.description,
+      project.icon,
+      project.category,
+      project.source,
+      project.github,
+      project.npm,
+      project.website,
+      project.downloads_monthly,
+      project.downloads_weekly,
+      project.stars
+    FROM projects AS project
     ${whereClause}
     ORDER BY
-      stars DESC,
-      downloads_monthly DESC,
-      downloads_weekly DESC,
-      name COLLATE NOCASE ASC
+      project.stars DESC,
+      project.downloads_monthly DESC,
+      project.downloads_weekly DESC,
+      project.name COLLATE NOCASE ASC
     LIMIT ?
     OFFSET ?
   `)
 
   const totalStatement = event.context.database.prepare(`
     SELECT COUNT(*) AS total
-    FROM projects
+    FROM projects AS project
     ${whereClause}
   `)
 

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -39,6 +39,8 @@ export type ProjectMetaStats = Record<ProjectMetaStatType, ProjectMetaStat[]>
 export interface ProjectFilters {
   category?: string
   source?: string
+  type?: string
+  tag?: string
   downloads_monthly?: number
   downloads_weekly?: number
   stars?: number


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Category pages listed all projects without any filtering, even though project metadata (types and tags) is already stored in the `project-meta` table (introduced in #32). This PR adds type/tag filtering to the category page project list.

Solution:

- `server/api/projects.get.ts` accepts new `type` and `tag` query parameters, filtering via `EXISTS` subqueries against `project-meta`. Existing conditions are now qualified with the `project` table alias.
- `shared/types/project.ts` extends `ProjectFilters` with `type` and `tag`.
- `app/composables/useProjects.ts` accepts reactive filters (`MaybeRefOrGetter`), refetches automatically when filters change, resets pagination state on filter changes, and discards stale "load more" responses.
- `app/composables/useProjectMeta.ts` (new) fetches `/api/projects/{category}/meta` reactively per category.
- `app/components/project/` (new): `ProjectProvider` owns the category/filter state and provides a `reka-ui` context; `ProjectSearch` renders metadata filter sections; `MetaSection` renders toggleable filter buttons with `aria-pressed`; `ProjectContent` renders the project grid, error state and "View More" button.
- `app/pages/[category].vue` is simplified to compose `ProjectProvider` + `ProjectSearch` + `ProjectContent`.

### 📝 Change Log

- Category pages now render filter sections built from project metadata; toggling a value filters the project list and resets pagination.
- The `/api/projects` endpoint supports new `type` and `tag` query parameters.
- `useProjects` accepts reactive filters and keeps paginated results consistent when filters change mid-request.
- The category page is split into reusable `project/*` components sharing a `reka-ui` context.
