### PR TITLE
fix(server): remove leftover debug console log from database plugin

### DIFF
--- a/server/plugins/database.ts
+++ b/server/plugins/database.ts
@@ -28,7 +28,6 @@ async function resolveDatabasePath() {
 
 export default defineNitroPlugin(async (nitroApp) => {
   const databasePath = await resolveDatabasePath()
-  console.log('111111', databasePath)
 
   const database = createDatabase(nodeSqliteConnector({ path: databasePath }))
 


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The database Nitro plugin printed a leftover debug line (`console.log('111111', databasePath)`) to the server output on every startup. This PR removes the stray debug statement so the plugin no longer produces noise in server logs.

### 📝 Change Log

- Removed a leftover debug `console.log` from the database plugin startup.
