### PR TITLE
fix(shared): rename hooks category label to Vue Composables

### DIFF
--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -8,7 +8,7 @@ export interface CategoryDefinition {
 export const projectCategoryMetadata: CategoryDefinition[] = [
   { id: 'ui', label: 'UI Libraries' },
   { id: 'component', label: 'Components' },
-  { id: 'hooks', label: 'Hooks and Composables' },
+  { id: 'hooks', label: 'Vue Composables' },
   { id: 'nuxt', label: 'Nuxt Modules' },
   { id: 'plugin', label: 'Vite Plugins' },
   { id: 'starter', label: 'Starters' },


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The `hooks` category was labeled "Hooks and Composables", which is redundant since "composables" is the Vue-specific term for hooks. This PR renames the label to "Vue Composables" in `projectCategoryMetadata`, so the new title shows up on the category page and in the category grid.

### 📝 Change Log

- The `hooks` category label is now "Vue Composables" instead of "Hooks and Composables".
