### PR TITLE
fix(app): restore ability to clear project filter selection

### DIFF
--- a/app/components/project/MetaSelect.vue
+++ b/app/components/project/MetaSelect.vue
@@ -3,12 +3,15 @@
     <span class="mr-2 text-xs whitespace-nowrap text-muted-foreground font-medium">
       {{ title }}
     </span>
-    <Select v-model="model">
+    <Select v-model="selectedValue">
       <SelectTrigger class="w-[180px] bg-background">
         <SelectValue :placeholder="`Select ${title.toLowerCase()}`" />
       </SelectTrigger>
       <SelectContent>
         <SelectGroup>
+          <SelectItem :value="ALL_OPTION_VALUE">
+            All
+          </SelectItem>
           <SelectItem
             v-for="option in options"
             :key="option"
@@ -33,4 +36,13 @@ defineProps<{
 }>()
 
 const model = defineModel<string>()
+
+const ALL_OPTION_VALUE = '__all__'
+
+const selectedValue = computed({
+  get: () => model.value ?? ALL_OPTION_VALUE,
+  set: (value) => {
+    model.value = value === ALL_OPTION_VALUE ? undefined : value
+  },
+})
 </script>


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [x] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Replacing the toggle buttons with `Select` dropdowns in #42 removed the ability to clear a chosen `Type` or `Tag` — a `Select` only supports picking an explicit option, so a selected filter could never be reset. This PR adds an `All` option that clears the selection:

- Adds an `All` item at the top of each dropdown with an `__all__` sentinel value.
- Exposes it to the select through a writable `selectedValue` computed that maps `__all__` to `undefined`, so the context keeps storing cleared selections as before.

### 📝 Change Log

- The `Type`/`Tag` filter dropdowns now include an `All` option that resets the filter.
