### PR TITLE
feat(app): wire project search input to keyword filtering

### DIFF
--- a/app/components/project/Search.vue
+++ b/app/components/project/Search.vue
@@ -4,7 +4,12 @@
     <div class="relative flex items-center gap-4">
       <div class="relative">
         <InputGroup class="bg-background w-[220px] lg:w-[280px]">
-          <InputGroupInput placeholder="Search..." />
+          <InputGroupInput
+            v-model="keyword"
+            type="search"
+            aria-label="Search projects"
+            placeholder="Search..."
+          />
           <InputGroupAddon>
             <Icon name="lucide:search" />
           </InputGroupAddon>
@@ -35,7 +40,7 @@ const metaSectionLabels: Record<ProjectMetaStatType, string> = {
 
 const metaTypes: ProjectMetaStatType[] = ['types', 'tags']
 
-const { category, selectedMeta } = useProjectResourceContext()
+const { category, keyword, selectedMeta } = useProjectResourceContext()
 const { data: meta } = await useProjectMeta(category)
 
 const sections = computed(() => metaTypes

--- a/app/components/project/index.ts
+++ b/app/components/project/index.ts
@@ -7,6 +7,7 @@ export type ProjectMetaSelection = Record<ProjectMetaStatType, string | undefine
 
 export interface ProjectResourceContext {
   category: ComputedRef<ProjectCategory>
+  keyword: Ref<string>
   selectedMeta: ProjectMetaSelection
   projects: Readonly<Ref<readonly ProjectRecord[]>>
   hasMore: Readonly<Ref<boolean>>

--- a/app/components/project/provider.vue
+++ b/app/components/project/provider.vue
@@ -15,11 +15,14 @@ const props = defineProps<{
 }>()
 
 const category = computed(() => props.category)
+const keyword = shallowRef('')
+const debouncedKeyword = refDebounced(keyword, 300)
 const selectedMeta = reactive<Record<ProjectMetaStatType, string | undefined>>({
   types: undefined,
   tags: undefined,
 })
 const filters = computed<ProjectFilters>(() => ({
+  keyword: debouncedKeyword.value.trim() || undefined,
   category: category.value,
   type: selectedMeta.types,
   tag: selectedMeta.tags,
@@ -40,6 +43,7 @@ watch(category, () => {
 
 provideProjectResourceContext({
   category,
+  keyword,
   selectedMeta,
   projects,
   hasMore,

--- a/server/api/projects.get.ts
+++ b/server/api/projects.get.ts
@@ -8,8 +8,13 @@ const numericFilterColumns = [
 
 const pageSize = 12
 
+function escapeLikePattern(value: string) {
+  return value.replace(/[\\%_]/g, character => `\\${character}`)
+}
+
 const querySchema = z.object({
   more: z.coerce.number().int().min(0).max(100).default(0),
+  keyword: z.string().trim().optional().default(''),
   category: z.string().trim().optional().default(''),
   source: z.string().trim().optional().default(''),
   type: z.string().trim().optional().default(''),
@@ -25,6 +30,7 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
   const offset = page * pageSize
 
   const filters: ProjectFilters = {
+    keyword: query.keyword,
     category: query.category,
     source: query.source,
     type: query.type,
@@ -36,6 +42,11 @@ export default defineEventHandler(async (event): Promise<ProjectsResponse> => {
 
   const conditions: string[] = []
   const parameters: Array<number | string> = []
+
+  if (filters.keyword) {
+    conditions.push(`project.name LIKE ? ESCAPE '\\' COLLATE NOCASE`)
+    parameters.push(`%${escapeLikePattern(filters.keyword)}%`)
+  }
 
   if (filters.category) {
     conditions.push('project.category = ?')

--- a/shared/types/project.ts
+++ b/shared/types/project.ts
@@ -37,6 +37,7 @@ export interface ProjectMetaStat {
 export type ProjectMetaStats = Record<ProjectMetaStatType, ProjectMetaStat[]>
 
 export interface ProjectFilters {
+  keyword?: string
   category?: string
   source?: string
   type?: string


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The project toolbar introduced in #42 contained a search input that was purely visual. This PR wires it to real keyword filtering:

- Binds the input to a `keyword` ref exposed through the project resource context (`type="search"` with an `aria-label`).
- Debounces the keyword by 300ms with `refDebounced` in the provider and includes it in `ProjectFilters`.
- Extends the projects API with a `keyword` query param that filters by a case-insensitive `LIKE` on `project.name`, escaping `\`, `%`, and `_` wildcards.
- Resets pagination naturally since filters are part of the existing query flow.

### 📝 Change Log

- The projects toolbar search box now filters projects by name as you type (debounced), on both desktop and category pages served by the projects API.
