### PR TITLE
feat: remove tag filter from project search

### DIFF
--- a/app/components/project/Search.vue
+++ b/app/components/project/Search.vue
@@ -38,7 +38,7 @@ const metaSectionLabels: Record<ProjectMetaStatType, string> = {
   tags: 'Tag',
 }
 
-const metaTypes: ProjectMetaStatType[] = ['types', 'tags']
+const metaTypes: ProjectMetaStatType[] = ['types']
 
 const { category, keyword, selectedMeta } = useProjectResourceContext()
 const { data: meta } = await useProjectMeta(category)

--- a/server/api/projects/[category]/meta.get.ts
+++ b/server/api/projects/[category]/meta.get.ts
@@ -31,7 +31,7 @@ export default defineEventHandler(async (event): Promise<ProjectMetaStats> => {
       ON project.id = meta.project_id
     WHERE
       project.category = ?
-      AND meta.type IN ('tags', 'types')
+      AND meta.type = 'types'
     GROUP BY
       meta.type,
       meta."values"


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [x] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The project search filter currently exposes two meta dimensions: types and tags. The tags dimension adds extra UI complexity in the search panel and an additional aggregation in the category meta API, but is not needed for the current search experience.

This PR removes the tags dimension so that:

- The search filter section only renders the types selector (`app/components/project/Search.vue`).
- The category meta endpoint (`server/api/projects/[category]/meta.get.ts`) only aggregates `types` stats and no longer queries `tags` rows.

### 📝 Change Log

- Project search no longer offers tag filtering; only type filtering remains.
- `GET /api/projects/:category/meta` now returns only `types` stats.
