### PR TITLE
feat(app): add category descriptions to page headers

### DIFF
--- a/app/components/PageHeader.ts
+++ b/app/components/PageHeader.ts
@@ -7,16 +7,25 @@ export default defineComponent({
       type: String,
       required: true,
     },
+    description: {
+      type: String,
+      required: true,
+    },
   },
   setup(props) {
     return () => h(
       'div',
       { class: 'p-6 border-b md:p-8 lg:p-10' },
-      h(
-        'h1',
-        { class: 'text-2xl font-semibold leading-snug tracking-tighter md:text-3xl lg:text-5xl' },
-        props.title,
-      ),
+      [
+        h(
+          'h1',
+          { class: 'text-2xl font-semibold leading-snug tracking-tighter md:text-3xl lg:text-5xl' },
+          props.title,
+        ),
+        h('p', {
+          class: 'text-muted-foreground text-sm leading-relaxed md:text-lg lg:text-xl',
+        }, props.description),
+      ],
     )
   },
 })

--- a/app/pages/[category].vue
+++ b/app/pages/[category].vue
@@ -1,6 +1,6 @@
 <template>
   <div class="hidden p-7.5 md:block" />
-  <PageHeader :title="title" />
+  <PageHeader :title="meta.label" :description="meta.description" />
 
   <ProjectProvider :category="category">
     <ProjectSearch />
@@ -22,5 +22,5 @@ if (!projectCategoryIds.includes(category.value)) {
   throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
 }
 
-const title = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value)?.label ?? '')
+const meta = computed(() => projectCategoryMetadata.find(({ id }) => id === category.value) ?? { label: '', description: '' })
 </script>

--- a/shared/constants/category.ts
+++ b/shared/constants/category.ts
@@ -3,20 +3,65 @@ import type { ProjectCategory } from '~~/packages/schema/src/types.ts'
 export interface CategoryDefinition {
   id: ProjectCategory
   label: string
+  description: string
 }
 
 export const projectCategoryMetadata: CategoryDefinition[] = [
-  { id: 'ui', label: 'UI Libraries' },
-  { id: 'component', label: 'Components' },
-  { id: 'hooks', label: 'Vue Composables' },
-  { id: 'nuxt', label: 'Nuxt Modules' },
-  { id: 'plugin', label: 'Vite Plugins' },
-  { id: 'starter', label: 'Starters' },
-  { id: 'utilities', label: 'Utilities' },
-  { id: 'library', label: 'Libraries' },
-  { id: 'tool', label: 'Developer Tools' },
-  { id: 'admin', label: 'Admin Templates' },
-  { id: 'uniapp', label: 'UniApp Ecosystem' },
+  {
+    id: 'ui',
+    label: 'UI Libraries',
+    description: 'Discover UI libraries and design systems built for Vue.',
+  },
+  {
+    id: 'component',
+    label: 'Components',
+    description: 'Explore reusable Vue components for building modern interfaces.',
+  },
+  {
+    id: 'hooks',
+    label: 'Vue Composables',
+    description: 'Discover reusable Vue composables for common application needs.',
+  },
+  {
+    id: 'nuxt',
+    label: 'Nuxt Modules',
+    description: 'Explore modules that extend and enhance your Nuxt applications.',
+  },
+  {
+    id: 'plugin',
+    label: 'Tooling Plugins',
+    description: 'Discover plugins across Vite, Rollup, Rolldown and Unplugin.',
+  },
+  {
+    id: 'starter',
+    label: 'Starters',
+    description: 'Find starter templates and boilerplates for Vue and Nuxt projects.',
+  },
+  {
+    id: 'utilities',
+    label: 'Utilities',
+    description: 'Discover utility libraries that simplify everyday Vue development.',
+  },
+  {
+    id: 'library',
+    label: 'Libraries',
+    description: 'Explore libraries that extend the capabilities of Vue applications.',
+  },
+  {
+    id: 'tool',
+    label: 'Developer Tools',
+    description: 'Discover developer tools for building, debugging and maintaining Vue projects.',
+  },
+  {
+    id: 'admin',
+    label: 'Admin Templates',
+    description: 'Explore admin dashboards and management templates built with Vue.',
+  },
+  {
+    id: 'uniapp',
+    label: 'UniApp Ecosystem',
+    description: 'Discover libraries, components and tools for the UniApp ecosystem.',
+  },
 ]
 
 export const projectCategoryIds = projectCategoryMetadata.map(c => c.id) as string[]


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Category pages currently show only the category label as a page title, giving
users little context about what each category contains.

This adds a `description` field to every entry in `projectCategoryMetadata`
and renders it below the title in `PageHeader`:

- `PageHeader` accepts a new required `description` prop rendered as muted
  text under the title.
- The `[category]` page passes both `meta.label` and `meta.description` to
  `PageHeader`.
- The `plugin` category label is renamed from "Vite Plugins" to
  "Tooling Plugins" to reflect that it covers Vite, Rollup, Rolldown and
  Unplugin plugins.

### 📝 Change Log

- Category pages now display a short description under the page title.
- The "Vite Plugins" category is renamed to "Tooling Plugins".
