### PR TITLE
chore(data): sync project stats

### DIFF
--- a/packages/data-admin/src/art-design-pro.ts
+++ b/packages/data-admin/src/art-design-pro.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 5854,
+    stars: 5858,
   },
 })

--- a/packages/data-admin/src/buildadmin.ts
+++ b/packages/data-admin/src/buildadmin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 2377,
+    stars: 2378,
   },
 })

--- a/packages/data-admin/src/cool-admin-midway.ts
+++ b/packages/data-admin/src/cool-admin-midway.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3273,
+    stars: 3272,
   },
 })

--- a/packages/data-admin/src/fantastic-admin.ts
+++ b/packages/data-admin/src/fantastic-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3388,
+    stars: 3389,
   },
 })

--- a/packages/data-admin/src/fast-soy-admin.ts
+++ b/packages/data-admin/src/fast-soy-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 393,
+    stars: 394,
   },
 })

--- a/packages/data-admin/src/gin-vue-admin.ts
+++ b/packages/data-admin/src/gin-vue-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 24996,
+    stars: 24997,
   },
 })

--- a/packages/data-admin/src/go-admin.ts
+++ b/packages/data-admin/src/go-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 12761,
+    stars: 12763,
   },
 })

--- a/packages/data-admin/src/mall-admin-web.ts
+++ b/packages/data-admin/src/mall-admin-web.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 12621,
+    stars: 12622,
   },
 })

--- a/packages/data-admin/src/ruoyi-plus-soybean.ts
+++ b/packages/data-admin/src/ruoyi-plus-soybean.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 324,
+    stars: 325,
   },
 })

--- a/packages/data-admin/src/ruoyi-vue3.ts
+++ b/packages/data-admin/src/ruoyi-vue3.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 6737,
+    stars: 6739,
   },
 })

--- a/packages/data-admin/src/smart-admin.ts
+++ b/packages/data-admin/src/smart-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3863,
+    stars: 3864,
   },
 })

--- a/packages/data-admin/src/soybean-admin.ts
+++ b/packages/data-admin/src/soybean-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 14975,
+    stars: 14980,
   },
 })

--- a/packages/data-admin/src/v3-admin-vite.ts
+++ b/packages/data-admin/src/v3-admin-vite.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 7054,
+    stars: 7058,
   },
 })

--- a/packages/data-admin/src/vue-admin-better.ts
+++ b/packages/data-admin/src/vue-admin-better.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 18925,
+    stars: 18926,
   },
 })

--- a/packages/data-admin/src/vue-element-plus-admin.ts
+++ b/packages/data-admin/src/vue-element-plus-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3692,
+    stars: 3693,
   },
 })

--- a/packages/data-admin/src/vue-fastapi-admin.ts
+++ b/packages/data-admin/src/vue-fastapi-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 2247,
+    stars: 2249,
   },
 })

--- a/packages/data-admin/src/vue-pure-admin.ts
+++ b/packages/data-admin/src/vue-pure-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 20612,
+    stars: 20613,
   },
 })

--- a/packages/data-admin/src/vue-vben-admin.ts
+++ b/packages/data-admin/src/vue-vben-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 33390,
+    stars: 33399,
   },
 })

--- a/packages/data-admin/src/vue3-admin.ts
+++ b/packages/data-admin/src/vue3-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3470,
+    stars: 3471,
   },
 })

--- a/packages/data-admin/src/vue3-element-admin.ts
+++ b/packages/data-admin/src/vue3-element-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 2584,
+    stars: 2586,
   },
 })

--- a/packages/data-admin/src/yudao-ui-admin-vue3.ts
+++ b/packages/data-admin/src/yudao-ui-admin-vue3.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 3813,
+    stars: 3817,
   },
 })

--- a/packages/data-admin/src/zhontai-admin.ts
+++ b/packages/data-admin/src/zhontai-admin.ts
@@ -19,6 +19,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 1724,
+    stars: 1725,
   },
 })

--- a/packages/data-component/src/ant-design-x-vue.ts
+++ b/packages/data-component/src/ant-design-x-vue.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/ant-design-x-vue',
   },
   stats: {
-    stars: 1828,
+    stars: 1829,
     downloads: {
       monthly: 7331,
       weekly: 1616,

--- a/packages/data-component/src/embla-carousel.ts
+++ b/packages/data-component/src/embla-carousel.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/embla-carousel-vue',
   },
   stats: {
-    stars: 8411,
+    stars: 8412,
     downloads: {
       monthly: 2547810,
       weekly: 604805,

--- a/packages/data-component/src/formkit.ts
+++ b/packages/data-component/src/formkit.ts
@@ -18,10 +18,10 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@formkit/vue',
   },
   stats: {
-    stars: 4758,
+    stars: 4762,
     downloads: {
-      monthly: 0,
-      weekly: 0,
+      monthly: 480284,
+      weekly: 78557,
     },
   },
 })

--- a/packages/data-component/src/fullcalendar.ts
+++ b/packages/data-component/src/fullcalendar.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@fullcalendar/vue3',
   },
   stats: {
-    stars: 20631,
+    stars: 20633,
     downloads: {
       monthly: 825274,
       weekly: 185674,

--- a/packages/data-component/src/markstream-vue.ts
+++ b/packages/data-component/src/markstream-vue.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://markstream.simonhe.me',
   },
   stats: {
-    stars: 2996,
+    stars: 3001,
     downloads: {
       monthly: 125989,
       weekly: 31688,

--- a/packages/data-component/src/md-editor-v3.ts
+++ b/packages/data-component/src/md-editor-v3.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/md-editor-v3',
   },
   stats: {
-    stars: 2584,
+    stars: 2586,
     downloads: {
       monthly: 170383,
       weekly: 39167,

--- a/packages/data-component/src/milkdown.ts
+++ b/packages/data-component/src/milkdown.ts
@@ -18,10 +18,10 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@milkdown/vue',
   },
   stats: {
-    stars: 11898,
+    stars: 11902,
     downloads: {
-      monthly: 35168,
-      weekly: 6255,
+      monthly: 0,
+      weekly: 0,
     },
   },
 })

--- a/packages/data-component/src/number-flow.ts
+++ b/packages/data-component/src/number-flow.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@number-flow/vue',
   },
   stats: {
-    stars: 7681,
+    stars: 7686,
     downloads: {
       monthly: 166099,
       weekly: 37404,

--- a/packages/data-component/src/tanstack-form.ts
+++ b/packages/data-component/src/tanstack-form.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@tanstack/vue-form',
   },
   stats: {
-    stars: 6680,
+    stars: 6679,
     downloads: {
       monthly: 234119,
       weekly: 55278,

--- a/packages/data-component/src/tanstack-table.ts
+++ b/packages/data-component/src/tanstack-table.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@tanstack/vue-table',
   },
   stats: {
-    stars: 28417,
+    stars: 28418,
     downloads: {
       monthly: 3774002,
       weekly: 879498,

--- a/packages/data-component/src/tanstack-virtual.ts
+++ b/packages/data-component/src/tanstack-virtual.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@tanstack/vue-virtual',
   },
   stats: {
-    stars: 7103,
+    stars: 7102,
     downloads: {
       monthly: 11954988,
       weekly: 2413486,

--- a/packages/data-component/src/tiptap.ts
+++ b/packages/data-component/src/tiptap.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@tiptap/vue-3',
   },
   stats: {
-    stars: 38307,
+    stars: 38325,
     downloads: {
       monthly: 6007996,
       weekly: 1449857,

--- a/packages/data-component/src/tresjs.ts
+++ b/packages/data-component/src/tresjs.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@tresjs/core',
   },
   stats: {
-    stars: 3700,
+    stars: 3701,
     downloads: {
       monthly: 170521,
       weekly: 32096,

--- a/packages/data-component/src/v-viewer.ts
+++ b/packages/data-component/src/v-viewer.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/v-viewer',
   },
   stats: {
-    stars: 2638,
+    stars: 2639,
     downloads: {
       monthly: 146292,
       weekly: 27522,

--- a/packages/data-component/src/virtua.ts
+++ b/packages/data-component/src/virtua.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/virtua',
   },
   stats: {
-    stars: 3737,
+    stars: 3738,
     downloads: {
       monthly: 3743766,
       weekly: 884423,

--- a/packages/data-component/src/vue-bits.ts
+++ b/packages/data-component/src/vue-bits.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-bits',
   },
   stats: {
-    stars: 4402,
+    stars: 4404,
     downloads: {
       monthly: 1132,
       weekly: 326,

--- a/packages/data-component/src/vue-codemirror.ts
+++ b/packages/data-component/src/vue-codemirror.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-codemirror',
   },
   stats: {
-    stars: 3478,
+    stars: 3479,
     downloads: {
       monthly: 434899,
       weekly: 98664,

--- a/packages/data-component/src/vue-cropper.ts
+++ b/packages/data-component/src/vue-cropper.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-cropper',
   },
   stats: {
-    stars: 4558,
+    stars: 4557,
     downloads: {
       monthly: 176875,
       weekly: 42207,

--- a/packages/data-component/src/vue-draggable-plus.ts
+++ b/packages/data-component/src/vue-draggable-plus.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-draggable-plus',
   },
   stats: {
-    stars: 4015,
+    stars: 4017,
     downloads: {
       monthly: 1123695,
       weekly: 267667,

--- a/packages/data-component/src/vue-echarts.ts
+++ b/packages/data-component/src/vue-echarts.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-echarts',
   },
   stats: {
-    stars: 10747,
+    stars: 10750,
     downloads: {
       monthly: 1620988,
       weekly: 387077,

--- a/packages/data-component/src/vue-flow.ts
+++ b/packages/data-component/src/vue-flow.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@vue-flow/core',
   },
   stats: {
-    stars: 6830,
+    stars: 6833,
     downloads: {
       monthly: 1975003,
       weekly: 476176,

--- a/packages/data-component/src/vue-maplibre-gl.ts
+++ b/packages/data-component/src/vue-maplibre-gl.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-maplibre-gl',
   },
   stats: {
-    stars: 164,
+    stars: 165,
     downloads: {
       monthly: 3679,
       weekly: 525,

--- a/packages/data-component/src/vue-qrcode-reader.ts
+++ b/packages/data-component/src/vue-qrcode-reader.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-qrcode-reader',
   },
   stats: {
-    stars: 2307,
+    stars: 2308,
     downloads: {
       monthly: 242085,
       weekly: 56394,

--- a/packages/data-component/src/vue-signature-pad.ts
+++ b/packages/data-component/src/vue-signature-pad.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-signature-pad',
   },
   stats: {
-    stars: 565,
+    stars: 566,
     downloads: {
       monthly: 198841,
       weekly: 49027,

--- a/packages/data-component/src/vue-sonner.ts
+++ b/packages/data-component/src/vue-sonner.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-sonner',
   },
   stats: {
-    stars: 1461,
+    stars: 1462,
     downloads: {
       monthly: 5204013,
       weekly: 1057665,

--- a/packages/data-component/src/vue-virtual-scroller.ts
+++ b/packages/data-component/src/vue-virtual-scroller.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue-virtual-scroller',
   },
   stats: {
-    stars: 10795,
+    stars: 10796,
     downloads: {
       monthly: 2155919,
       weekly: 450440,

--- a/packages/data-component/src/vue3-carousel.ts
+++ b/packages/data-component/src/vue3-carousel.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/vue3-carousel',
   },
   stats: {
-    stars: 884,
+    stars: 885,
     downloads: {
       monthly: 418634,
       weekly: 101140,

--- a/packages/data-hooks/src/tanstack-vue-query.ts
+++ b/packages/data-hooks/src/tanstack-vue-query.ts
@@ -20,7 +20,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 50284,
+    stars: 50274,
     downloads: {
       monthly: 2766231,
       weekly: 652675,

--- a/packages/data-hooks/src/vueuse-core.ts
+++ b/packages/data-hooks/src/vueuse-core.ts
@@ -20,7 +20,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 22347,
+    stars: 22349,
     downloads: {
       monthly: 41201074,
       weekly: 9924968,

--- a/packages/data-ui/src/ant-design-vue.ts
+++ b/packages/data-ui/src/ant-design-vue.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://antdv.com',
   },
   stats: {
-    stars: 21642,
+    stars: 21643,
     downloads: {
       monthly: 942627,
       weekly: 168488,

--- a/packages/data-ui/src/arco-design-vue.ts
+++ b/packages/data-ui/src/arco-design-vue.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://arco.design/vue',
   },
   stats: {
-    stars: 3106,
+    stars: 3107,
     downloads: {
       monthly: 170289,
       weekly: 29634,

--- a/packages/data-ui/src/element-plus.ts
+++ b/packages/data-ui/src/element-plus.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://element-plus.org',
   },
   stats: {
-    stars: 27739,
+    stars: 27741,
     downloads: {
       monthly: 2730601,
       weekly: 618100,

--- a/packages/data-ui/src/inspira-ui.ts
+++ b/packages/data-ui/src/inspira-ui.ts
@@ -17,6 +17,6 @@ export default defineProjectMeta({
     website: 'https://inspira-ui.com',
   },
   stats: {
-    stars: 4971,
+    stars: 4973,
   },
 })

--- a/packages/data-ui/src/ionic.ts
+++ b/packages/data-ui/src/ionic.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://ionicframework.com',
   },
   stats: {
-    stars: 52647,
+    stars: 52651,
     downloads: {
       monthly: 250570,
       weekly: 57621,

--- a/packages/data-ui/src/naive-ui.ts
+++ b/packages/data-ui/src/naive-ui.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://www.naiveui.com',
   },
   stats: {
-    stars: 18535,
+    stars: 18536,
     downloads: {
       monthly: 666269,
       weekly: 107422,

--- a/packages/data-ui/src/nutui.ts
+++ b/packages/data-ui/src/nutui.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://nutui.jd.com',
   },
   stats: {
-    stars: 6509,
+    stars: 6510,
     downloads: {
       monthly: 12841,
       weekly: 3702,

--- a/packages/data-ui/src/primevue.ts
+++ b/packages/data-ui/src/primevue.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://primevue.org',
   },
   stats: {
-    stars: 14456,
+    stars: 14459,
     downloads: {
       monthly: 2898495,
       weekly: 762547,

--- a/packages/data-ui/src/quasar.ts
+++ b/packages/data-ui/src/quasar.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://quasar.dev',
   },
   stats: {
-    stars: 27211,
+    stars: 27212,
     downloads: {
       monthly: 1234942,
       weekly: 226032,

--- a/packages/data-ui/src/reka-ui.ts
+++ b/packages/data-ui/src/reka-ui.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://reka-ui.com',
   },
   stats: {
-    stars: 6778,
+    stars: 6783,
     downloads: {
       monthly: 6799498,
       weekly: 1642696,

--- a/packages/data-ui/src/shadcn-vue.ts
+++ b/packages/data-ui/src/shadcn-vue.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/shadcn-vue',
   },
   stats: {
-    stars: 10568,
+    stars: 10571,
     downloads: {
       monthly: 439869,
       weekly: 93740,

--- a/packages/data-ui/src/vuetify.ts
+++ b/packages/data-ui/src/vuetify.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
     website: 'https://vuetifyjs.com',
   },
   stats: {
-    stars: 41037,
+    stars: 41038,
     downloads: {
       monthly: 3823178,
       weekly: 905416,

--- a/packages/data-ui/src/wot-design-uni.ts
+++ b/packages/data-ui/src/wot-design-uni.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/wot-design-uni',
   },
   stats: {
-    stars: 2287,
+    stars: 2288,
     downloads: {
       monthly: 12449,
       weekly: 2750,

--- a/packages/data-ui/src/zag.ts
+++ b/packages/data-ui/src/zag.ts
@@ -18,7 +18,7 @@ export default defineProjectMeta({
     npm: 'https://www.npmjs.com/package/@zag-js/vue',
   },
   stats: {
-    stars: 5202,
+    stars: 5203,
     downloads: {
       monthly: 169234,
       weekly: 29538,

--- a/packages/data-uniapp/src/awesome-uni-app.ts
+++ b/packages/data-uniapp/src/awesome-uni-app.ts
@@ -17,6 +17,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 363,
+    stars: 364,
   },
 })

--- a/packages/data-uniapp/src/colorui.ts
+++ b/packages/data-uniapp/src/colorui.ts
@@ -17,6 +17,6 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 12381,
+    stars: 12380,
   },
 })

--- a/packages/data-uniapp/src/luch-request.ts
+++ b/packages/data-uniapp/src/luch-request.ts
@@ -20,7 +20,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 668,
+    stars: 669,
     downloads: {
       monthly: 3827,
       weekly: 810,

--- a/packages/data-uniapp/src/uni-echarts.ts
+++ b/packages/data-uniapp/src/uni-echarts.ts
@@ -20,7 +20,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 178,
+    stars: 179,
     downloads: {
       monthly: 1843,
       weekly: 393,

--- a/packages/data-uniapp/src/uview-ui.ts
+++ b/packages/data-uniapp/src/uview-ui.ts
@@ -20,7 +20,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 1786,
+    stars: 1788,
     downloads: {
       monthly: 26581,
       weekly: 3030,

--- a/packages/data-uniapp/src/wot-design-uni.ts
+++ b/packages/data-uniapp/src/wot-design-uni.ts
@@ -19,7 +19,7 @@ export default defineProjectMeta({
   },
 
   stats: {
-    stars: 2287,
+    stars: 2288,
     downloads: {
       monthly: 12449,
       weekly: 2750,


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [x] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Project meta files under `packages/data-*` carry GitHub stars and npm download stats that go stale over time. This PR refreshes them with `pnpm sync:npm-git-data`, which fetches the latest GitHub stars and npm monthly/weekly downloads and rewrites the `stats` block of each project meta file.

71 files updated across `data-admin`, `data-component`, `data-hooks`, `data-ui` and `data-uniapp`. No logic or schema changes.

### 📝 Change Log

- Refreshed `stars` counts across all project meta files.
- Updated npm `monthly`/`weekly` download stats for `formkit` and `milkdown`.
