### PR TITLE
feat(app): link hero Explore Ecosystem button to /ui

### DIFF
--- a/app/components/hero/index.vue
+++ b/app/components/hero/index.vue
@@ -30,8 +30,11 @@
 
         <div class="relative mt-10 flex flex-col items-start gap-3 md:flex-row">
           <Button class="flex h-auto gap-3 rounded-none font-medium md:py-3 md:text-base">
-            Explore Ecosystem
             <Icon name="lucide:chevron-right" />
+            <NuxtLink to="/ui">
+              Explore Ecosystem
+              <Icon name="lucide:chevron-right" />
+            </NuxtLink>
           </Button>
           <div class="flex gap-4">
             <Button class="flex h-auto gap-3 rounded-none font-medium md:px-5 md:py-3 md:text-base" variant="outline">


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The "Explore Ecosystem" button in the hero section was plain text and not linked anywhere. Its content is now wrapped in a `NuxtLink` pointing to `/ui`, so clicking the button navigates to the UI ecosystem page.

### 📝 Change Log

The hero "Explore Ecosystem" button now navigates to the UI ecosystem page (`/ui`).
