### PR TITLE
docs(data-hooks): use official English taglines for project descriptions

### DIFF
--- a/packages/data-hooks/src/ahooks-vue.ts
+++ b/packages/data-hooks/src/ahooks-vue.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'ahooks-vue',
-  description: 'ahooks 的 Vue 3 实现版本（已停止维护）',
+  description: '🛠️ Vue hooks library.',
   icon: 'thesvg-color:ahooks',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/pinia-colada.ts
+++ b/packages/data-hooks/src/pinia-colada.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'pinia-colada',
-  description: 'Vue 官方团队成员（posva）打造的智能数据请求层，基于 Pinia 提供 useQuery / useMutation',
+  description: '🍹 The smart data fetching layer for Vue',
   icon: 'logos:pinia',
   category: 'hooks',
   types: ['data-fetching', 'composable-library'],

--- a/packages/data-hooks/src/swrv.ts
+++ b/packages/data-hooks/src/swrv.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'swrv',
-  description: 'Vercel SWR 的 Vue 实现，stale-while-revalidate 数据请求 Hooks（Kong 出品）',
+  description: 'Stale-while-revalidate data fetching for Vue',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['data-fetching', 'composable-library'],

--- a/packages/data-hooks/src/tanstack-vue-query.ts
+++ b/packages/data-hooks/src/tanstack-vue-query.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'tanstack-vue-query',
-  description: 'TanStack Query 的 Vue 适配层，为 Vue 3 提供异步状态管理、缓存与数据请求',
+  description: '🤖 Powerful asynchronous state management, server-state utilities and data fetching for the web. TS/JS, React Query, Solid Query, Svelte Query and Vue Query.',
   icon: 'thesvg-color:tanstack',
   category: 'hooks',
   types: ['data-fetching', 'composable-library'],

--- a/packages/data-hooks/src/u3u-vue-hooks.ts
+++ b/packages/data-hooks/src/u3u-vue-hooks.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'u3u-vue-hooks',
-  description: 'Awesome Vue Hooks 集合，基于 Vue Composition API 的常用工具函数（已停止维护）',
+  description: '⚡️Awesome Vue Hooks',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/v3hooks.ts
+++ b/packages/data-hooks/src/v3hooks.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'v3hooks',
-  description: '针对 Vue 3 的实用 Hooks 集合，中文文档',
+  description: '针对 Vue3 的实用Hooks集合',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vooks.ts
+++ b/packages/data-hooks/src/vooks.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vooks',
-  description: 'Naive UI 作者出品的 Vue composables 工具集',
+  description: 'Utils Composable for Vue',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vue-composable.ts
+++ b/packages/data-hooks/src/vue-composable.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vue-composable',
-  description: '50+ Vue 组合式函数集合，覆盖 i18n、表单校验、分页、fetch 等场景（已停止维护）',
+  description: 'Vue composition-api composable components. i18n, validation, pagination, fetch, etc. +50 different composables',
   icon: 'icon:vue-composable',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vue-hooks-plus.ts
+++ b/packages/data-hooks/src/vue-hooks-plus.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vue-hooks-plus',
-  description: '高性能、简洁易用的 Vue 3 Hooks 库，API 风格对标 ahooks，中英文文档齐全',
+  description: 'High performance  & Simplicity  🧲  Vue 3 Hooks library',
   icon: 'icon:vue-hooks-plus',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vue-promised.ts
+++ b/packages/data-hooks/src/vue-promised.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vue-promised',
-  description: '组合式 Promise 封装，将异步状态渲染为组件与 composables',
+  description: '💝 Composable Promises & Promises as components',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['data-fetching', 'composable-library'],

--- a/packages/data-hooks/src/vue-request.ts
+++ b/packages/data-hooks/src/vue-request.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vue-request',
-  description: '请求状态管理库，支持 SWR、轮询、错误重试、缓存、分页等，中文文档完善',
+  description: '⚡️ This is a library that can easily help you manage request states, supporting common features such as SWR, polling, error retry, caching, and pagination, etc. ⚡️ 这是一个能够轻松帮助你管理请求状态的库，支持 SWR、轮询、错误重试、缓存、分页等常用功能。',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['data-fetching', 'composable-library'],

--- a/packages/data-hooks/src/vue-use-kit.ts
+++ b/packages/data-hooks/src/vue-use-kit.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vue-use-kit',
-  description: '轻量的 Vue 组合式 API 工具函数集合（已停止维护）',
+  description: '🛠️Useful collection of Vue composition API functions https://microcipcip.github.io/vue-use-kit/',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vueuse-core.ts
+++ b/packages/data-hooks/src/vueuse-core.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vueuse-core',
-  description: '事实标准级的 Vue 组合式工具集，300+ 开箱即用的 composables，并提供 router / rxjs / integrations 等官方子包',
+  description: 'Collection of essential Vue Composition Utilities for Vue 3',
   icon: 'logos:vueuse',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vueuse-gesture.ts
+++ b/packages/data-hooks/src/vueuse-gesture.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vueuse-gesture',
-  description: '手势交互 composables，支持拖拽、缩放、悬停等操作',
+  description: '🕹 Vue Composables making your app interactive',
   icon: 'logos:vueuse',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vueuse-motion.ts
+++ b/packages/data-hooks/src/vueuse-motion.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vueuse-motion',
-  description: 'Vue 组合式动画库，提供 v-motion 指令与 composables 驱动组件动效',
+  description: '🤹 Vue Composables putting your components in motion',
   icon: 'logos:vueuse',
   category: 'hooks',
   types: ['animation', 'composable-library'],

--- a/packages/data-hooks/src/vueuse-sound.ts
+++ b/packages/data-hooks/src/vueuse-sound.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vueuse-sound',
-  description: '播放音效的 Vue composable',
+  description: '🔊 A Vue composable for playing sound effects',
   icon: 'logos:vueuse',
   category: 'hooks',
   types: ['composable-library'],

--- a/packages/data-hooks/src/vuex-composition-helpers.ts
+++ b/packages/data-hooks/src/vuex-composition-helpers.ts
@@ -2,7 +2,7 @@ import { defineProjectMeta } from '@vuejs-community/schema'
 
 export default defineProjectMeta({
   name: 'vuex-composition-helpers',
-  description: '在 Composition API 中便捷使用 Vuex 4 的 map* 辅助函数（遗留 Vuex 项目适用）',
+  description: 'A util package to use Vuex with Composition API easily.',
   icon: 'dinkie-icons:hook',
   category: 'hooks',
   types: ['state-management', 'composable-library'],


### PR DESCRIPTION
### 🤔 This is a ...

- [ ] 🆕 New feature
- [ ] 🐞 Bug fix
- [x] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

The project descriptions under `packages/data-hooks/src` were hand-written in Chinese, which caused inconsistent tone, included outdated maintenance notes, and did not match the official wording of each library.

This PR replaces the `description` field of all 17 hooks project metas with each project's official English tagline (e.g. VueUse: "Collection of essential Vue Composition Utilities for Vue 3", VueUse Motion: "🤹 Vue Composables putting your components in motion").

### 📝 Change Log

- Replaced hand-written Chinese descriptions with official English taglines for all 17 projects in the hooks category, so the site displays consistent, up-to-date descriptions.
