### PR TITLE
feat(generate): add daily full-sync plugin snapshot pipeline

### DIFF
--- a/docs/generate-plugin-plan.md
+++ b/docs/generate-plugin-plan.md
@@ -1,0 +1,1422 @@
+# Plugin 数据每日全量生成方案
+
+## 1. 目标与边界
+
+本文定义一个每天执行一次的严格全量同步流程：
+
+1. 使用 npm Replication API 按指定包名前缀全量扫描包名。
+2. 对扫描得到的每个包全量检查最新 package metadata。
+3. 对全部有效包获取同一统计周期的日下载量和月下载量。
+4. 对全部存在 GitHub 仓库链接的包检查仓库 Stars；相同仓库只请求一次。
+5. 只有当本次所有必要数据完整时，才发布一个新的完整快照。
+
+公网 API 不存在“绝对不限流、永不失败”的承诺。因此脚本的可实现保证定义为：
+
+- 每个 API Host 使用独立限速器，不主动触发已知限流。
+- 429、服务端错误、网络错误和超时按协议等待并重试。
+- 所有任务有持久化状态，进程退出后可以继续同一轮同步。
+- 不用 `0`、空字符串、旧统计值或跳过失败记录作为兜底。
+- 任何必要数据失败或缺失时，本次快照不发布。
+- 已发布快照永远来自一次完整成功的同步。
+
+本文中的“全量”指每天对完整包集合执行检查。Package metadata 和 GitHub 请求允许使用 HTTP 条件请求：
+
+- `200 OK` 表示服务端返回了新实体。
+- `304 Not Modified` 表示服务端确认缓存实体仍然有效。
+- 只有本地存在与请求校验器严格匹配的缓存实体时，304 才算成功。
+- 网络错误时禁止使用缓存伪装成本次检查成功。
+
+## 2. 已验证的 API 行为
+
+以下响应形状已于 2026-09-09 通过官方端点做只读验证。
+
+### 2.1 Replication 索引
+
+请求：
+
+```text
+GET https://replicate.npmjs.com/registry/_all_docs
+```
+
+响应：
+
+```json
+{
+  "total_rows": 4374853,
+  "offset": 4167473,
+  "rows": [
+    {
+      "id": "vite-plugin-vue",
+      "key": "vite-plugin-vue",
+      "value": {
+        "rev": "8-0c3c957c9f21796a0f06bdf6e47d5fcb"
+      }
+    }
+  ]
+}
+```
+
+`total_rows` 是整个 Registry 的总包数，不是当前前缀的命中数。分页必须基于最后一个 `key`，不能使用全局 offset 推导前缀结果数量。
+
+### 2.2 Replication 数据库状态
+
+请求：
+
+```text
+GET https://replicate.npmjs.com/registry/
+```
+
+响应：
+
+```json
+{
+  "db_name": "registry",
+  "engine": "npm-replicate",
+  "doc_count": 4374853,
+  "update_seq": 129653228
+}
+```
+
+### 2.3 Replication Changes
+
+请求：
+
+```text
+GET https://replicate.npmjs.com/registry/_changes?since=<sequence>&limit=1000
+```
+
+响应：
+
+```json
+{
+  "results": [
+    {
+      "seq": 129643257,
+      "id": "@jsenv/core",
+      "changes": [
+        {
+          "rev": "1167-15d9aff07d7f7f96d83a720fa95f7455"
+        }
+      ]
+    }
+  ],
+  "last_seq": 129643259
+}
+```
+
+删除记录会额外包含 `deleted: true`。解析后必须把字段归一化为必有的 `boolean`。
+
+### 2.4 npm Package Metadata
+
+请求：
+
+```text
+GET https://registry.npmjs.org/{encodeURIComponent(packageName)}/latest
+```
+
+实测确认：
+
+- `name` 和 `version` 存在。
+- `description`、`keywords`、`repository`、`homepage`、`bugs`、`deprecated` 可能完全缺失。
+- `repository` 可能是字符串，也可能是 `{ url, type, directory }`，其中 `type` 和 `directory` 也可能缺失。
+- scoped 包必须把 `/` 编码为 `%2F`。
+- 响应带有 `Last-Modified` 时，发送 `If-Modified-Since` 可以得到 `304 Not Modified`。
+
+npm 官方 metadata 说明：[Package metadata](https://github.com/npm/registry/blob/main/docs/responses/package-metadata.md)。
+
+### 2.5 npm Downloads
+
+非 scoped bulk 响应是按包名索引的对象：
+
+```json
+{
+  "vite-plugin-vue-devtools": {
+    "downloads": 3972962,
+    "package": "vite-plugin-vue-devtools",
+    "start": "2026-08-10",
+    "end": "2026-09-08"
+  }
+}
+```
+
+scoped 单包响应是单个对象：
+
+```json
+{
+  "downloads": 0,
+  "package": "@rollup/plugin-alias",
+  "start": "2026-09-08",
+  "end": "2026-09-08"
+}
+```
+
+官方约束：
+
+- bulk 单次最多 128 个包。
+- scoped 包不支持 bulk。
+- scoped 包路径中的 `/` 必须编码。
+
+参考：[npm Downloads API](https://github.com/npm/registry/blob/main/docs/download-counts.md#bulk-queries)。
+
+### 2.6 GitHub Repository
+
+请求：
+
+```text
+GET https://api.github.com/repos/{owner}/{repository}
+```
+
+本流程只消费：
+
+```json
+{
+  "full_name": "vuejs/devtools",
+  "html_url": "https://github.com/vuejs/devtools",
+  "stargazers_count": 2904,
+  "archived": false,
+  "disabled": false
+}
+```
+
+响应头包含：
+
+```text
+etag
+last-modified
+x-ratelimit-limit
+x-ratelimit-remaining
+x-ratelimit-used
+x-ratelimit-reset
+retry-after
+```
+
+GitHub 未认证请求通常只有 60 次/小时，普通认证 Token 通常为 5000 次/小时。认证条件请求得到 304 时，不消耗主要 rate limit，但仍应控制请求速率以避免 secondary rate limit。
+
+参考：
+
+- [GitHub REST API rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
+- [GitHub conditional requests](https://docs.github.com/en/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests)
+
+## 3. 禁止事项
+
+最终实现必须明确禁止：
+
+- 用户指定的四种空值或顶层宽泛类型关键字。
+- TypeScript 可选属性 `field?: Type`。
+- 宽泛的 `object`、`{}` 或没有运行时校验的类型断言。
+- 非空断言操作符。
+- `catch` 后返回伪造值并继续执行。
+- 请求失败后沿用旧 Downloads 或旧 Stars 并把当日快照标记为成功。
+- 缺少 bulk 响应键时静默跳过。
+- GitHub 请求失败时把 Stars 写为 `0`。
+- npm Downloads 请求失败时把 Downloads 写为 `0`。
+- 对 400、401、403、404、422 等所有 4xx 无差别重试。
+- 重试绕过 Host 限速队列。
+- 边请求边修改正式快照。
+
+外部 JSON 中字段缺失是协议事实。传输层 schema 必须识别“字段存在”和“字段不存在”两种输入，并在解析边界转换为 `Presence<T>` 判别联合。业务层通过 `state` 分支穷尽处理，不以特殊值表达缺失、失败或尚未执行。
+
+## 4. 建议的代码模块
+
+入口脚本只负责装配和启动：
+
+```text
+generate-plugin-names.ts
+```
+
+业务代码拆分为：
+
+```text
+generate-plugin/
+├── contracts.ts
+├── schemas.ts
+├── clock.ts
+├── http-client.ts
+├── host-scheduler.ts
+├── replication-client.ts
+├── npm-registry-client.ts
+├── npm-downloads-client.ts
+├── github-client.ts
+├── repository-parser.ts
+├── state-store.ts
+├── snapshot-validator.ts
+├── snapshot-publisher.ts
+└── pipeline.ts
+```
+
+职责：
+
+- `contracts.ts`：所有规范化领域类型和 Result 类型。
+- `schemas.ts`：所有外部 JSON 的运行时 schema；推荐使用 Zod。
+- `clock.ts`：创建本轮唯一时间上下文，不允许在各阶段重复读取当前日期。
+- `http-client.ts`：只发送一次 HTTP 请求并返回结构化结果，不负责重试。
+- `host-scheduler.ts`：每个 Host 的并发、速率、重试、暂停和熔断。
+- `replication-client.ts`：前缀分页、sequence、changes 和包集合校验。
+- `npm-registry-client.ts`：对所有包执行每日 metadata 条件请求。
+- `npm-downloads-client.ts`：锚定统计周期、构建 bulk、单包 scoped 请求和批次完整性校验。
+- `github-client.ts`：仓库去重、条件请求、rate-limit 感知和 Stars 校验。
+- `repository-parser.ts`：从 npm metadata 中识别并规范化 GitHub 仓库。
+- `state-store.ts`：持久化 run、task、缓存实体和成功快照。
+- `snapshot-validator.ts`：执行全局集合相等性与状态检查。
+- `snapshot-publisher.ts`：生成 staging 快照并原子发布。
+- `pipeline.ts`：严格按五个阶段编排。
+
+## 5. 核心类型设计
+
+### 5.1 Result 与失败类型
+
+所有 API 边界返回 Result，不通过伪造业务值表达失败：
+
+```ts
+export type Result<T, E>
+  = | { ok: true, value: T }
+    | { ok: false, error: E }
+
+export type Presence<T>
+  = | { state: 'present', value: T }
+    | { state: 'absent' }
+
+export type RequestFailure
+  = | { kind: 'network', message: string }
+    | { kind: 'timeout', timeoutMs: number }
+    | {
+      kind: 'http'
+      status: number
+      body: string
+      retryAfterMs: Presence<number>
+      rateLimitRemaining: Presence<number>
+      rateLimitResetAt: Presence<number>
+    }
+    | { kind: 'schema', issues: readonly string[] }
+    | { kind: 'invariant', message: string }
+    | { kind: 'storage', operation: string, message: string }
+    | { kind: 'publish', operation: string, message: string }
+```
+
+响应头统一成显式判别联合：
+
+```ts
+export interface ResponseMetadata {
+  status: number
+  etag: Presence<string>
+  lastModified: Presence<string>
+  retryAfterMs: Presence<number>
+  rateLimitLimit: Presence<number>
+  rateLimitRemaining: Presence<number>
+  rateLimitUsed: Presence<number>
+  rateLimitResetAt: Presence<number>
+}
+```
+
+HTTP 成功响应只有两种：
+
+```ts
+export type HttpSuccess
+  = | {
+    kind: 'body'
+    body: string
+    metadata: ResponseMetadata
+  }
+  | {
+    kind: 'not-modified'
+    metadata: ResponseMetadata
+  }
+```
+
+### 5.2 Plugin 定义
+
+```ts
+export type PluginType
+  = | 'vite-plugin'
+    | 'rollup-plugin'
+    | 'rolldown-plugin'
+    | 'unplugin'
+
+export interface PluginDefinition {
+  directory: 'vite' | 'rollup' | 'rolldown' | 'unplugin'
+  packageNamePrefix: string
+  type: PluginType
+  icon: string
+}
+```
+
+所有字段必填，不使用可选属性。
+
+### 5.3 Replication 类型
+
+```ts
+export interface ReplicationInfo {
+  databaseName: string
+  engine: string
+  documentCount: number
+  updateSequence: number
+}
+
+export interface ReplicationIndexRow {
+  packageName: string
+  key: string
+  revision: string
+}
+
+export interface ReplicationPage {
+  totalRows: number
+  offset: number
+  rows: readonly ReplicationIndexRow[]
+}
+
+export interface ReplicationChange {
+  sequence: number
+  packageName: string
+  revision: string
+  deleted: boolean
+}
+
+export interface ReplicationChangesPage {
+  lastSequence: number
+  changes: readonly ReplicationChange[]
+}
+
+export interface PackageTarget {
+  packageName: string
+  revision: string
+  definition: PluginDefinition
+}
+
+export interface ReplicationSnapshot {
+  startSequence: number
+  endSequence: number
+  packages: readonly PackageTarget[]
+}
+```
+
+### 5.4 Package Metadata 类型
+
+只建模最终生成和 GitHub 识别真正消费的字段。响应中的其他字段由 schema 明确忽略，不使用宽泛索引签名承接。
+
+```ts
+export type NpmRepository
+  = | {
+    kind: 'string'
+    value: string
+  }
+  | {
+    kind: 'object'
+    url: string
+    type: Presence<string>
+    directory: Presence<string>
+  }
+
+export interface PackageMetadata {
+  name: string
+  version: string
+  description: Presence<string>
+  keywords: Presence<readonly string[]>
+  repository: Presence<NpmRepository>
+  homepage: Presence<string>
+  bugsUrl: Presence<string>
+  deprecated: Presence<string>
+}
+
+export interface PackageMetadataCache {
+  packageName: string
+  requestUrl: string
+  lastModified: Presence<string>
+  responseHash: string
+  metadata: PackageMetadata
+}
+
+export type PackageMetadataRecord
+  = | {
+    validation: 'response-200'
+    target: PackageTarget
+    metadata: PackageMetadata
+    cacheValidator: Presence<string>
+  }
+  | {
+    validation: 'response-304'
+    target: PackageTarget
+    metadata: PackageMetadata
+    cacheValidator: string
+  }
+```
+
+对于实际缺失的 description、keywords、repository 等字段，schema 输出 `{ state: 'absent' }`。禁止输出空字符串或空数组来掩盖字段缺失。
+
+### 5.5 Downloads 类型
+
+```ts
+export type DownloadMetricKind = 'daily' | 'monthly'
+
+export interface DownloadPeriod {
+  kind: DownloadMetricKind
+  start: string
+  end: string
+  apiPeriod: string
+}
+
+export interface DownloadPoint {
+  packageName: string
+  downloads: number
+  start: string
+  end: string
+}
+
+export interface PackageDownloads {
+  packageName: string
+  daily: DownloadPoint
+  monthly: DownloadPoint
+}
+
+export interface DownloadBatch {
+  kind: DownloadMetricKind
+  requestedPackageNames: readonly string[]
+  requestUrl: string
+}
+
+export interface CompletedDownloadBatch {
+  batch: DownloadBatch
+  points: readonly DownloadPoint[]
+}
+```
+
+Bulk JSON 不直接暴露为 `Record<string, DownloadPoint>` 进入业务层。Decoder 必须先校验响应 key 集合与请求集合完全一致，再输出 `CompletedDownloadBatch`。
+
+### 5.6 GitHub 类型
+
+```ts
+export interface GitHubRepositoryTarget {
+  fullName: string
+  owner: string
+  repository: string
+}
+
+export type PackageGitHubTarget
+  = | {
+    kind: 'repository'
+    packageName: string
+    target: GitHubRepositoryTarget
+  }
+  | {
+    kind: 'absent'
+    packageName: string
+  }
+
+export interface GitHubRepositoryData {
+  fullName: string
+  htmlUrl: string
+  stars: number
+  archived: boolean
+  disabled: boolean
+}
+
+export interface GitHubRepositoryCache {
+  fullName: string
+  etag: string
+  responseHash: string
+  data: GitHubRepositoryData
+}
+
+export interface GitHubRepositoryRecord {
+  data: GitHubRepositoryData
+  etag: string
+  validation: 'response-200' | 'response-304'
+}
+
+export type PackageGitHubData
+  = | {
+    kind: 'repository'
+    packageName: string
+    repository: GitHubRepositoryRecord
+  }
+  | {
+    kind: 'absent'
+    packageName: string
+  }
+```
+
+GitHub URL 缺失是合法的 `absent`。存在可识别的 GitHub URL 后，GitHub API 未成功则整个快照失败，不能转成 `absent`。
+
+### 5.7 完整快照类型
+
+```ts
+export interface PluginSnapshotEntry {
+  target: PackageTarget
+  packageMetadata: PackageMetadataRecord
+  downloads: PackageDownloads
+  github: PackageGitHubData
+}
+
+export interface CompletePluginSnapshot {
+  snapshotId: string
+  startedAt: string
+  completedAt: string
+  replicationStartSequence: number
+  replicationEndSequence: number
+  dailyPeriod: DownloadPeriod
+  monthlyPeriod: DownloadPeriod
+  entries: readonly PluginSnapshotEntry[]
+}
+```
+
+这个类型没有 partial、pending 或 retry 分支。只有通过最终校验的数据才能构造 `CompletePluginSnapshot`。
+
+## 6. Schema 设计
+
+外部 JSON 必须先经过运行时 schema，不能直接做 TypeScript 类型断言。
+
+推荐为以下响应分别建立 Zod schema：
+
+```text
+ReplicationInfoSchema
+ReplicationPageSchema
+ReplicationChangesPageSchema
+PackageMetadataSchema
+DownloadPointSchema
+DownloadBulkResponseSchema
+GitHubRepositorySchema
+```
+
+Schema 规则：
+
+- 数字必须是 finite number；计数必须是非负整数。
+- 日期必须匹配 `YYYY-MM-DD` 并通过实际日期校验。
+- npm package name 必须与请求目标完全一致。
+- GitHub `full_name` 必须与请求的 `owner/repository` 忽略大小写后一致。
+- 外部允许缺失的 metadata 字段在 schema 输出阶段统一为 `{ state: 'absent' }`。
+- `keywords` 存在时必须是字符串数组；错误元素不能被过滤后继续。
+- repository 对象存在时必须包含非空 URL。
+- schema 失败产生 `RequestFailure.kind === 'schema'`，并阻止快照发布。
+
+Decoder 函数固定签名：
+
+```ts
+export function decodeReplicationInfo(body: string): Result<ReplicationInfo, RequestFailure>
+
+export function decodeReplicationPage(body: string): Result<ReplicationPage, RequestFailure>
+
+export function decodeReplicationChangesPage(body: string): Result<ReplicationChangesPage, RequestFailure>
+
+export function decodePackageMetadata(
+  body: string,
+  expectedPackageName: string,
+): Result<PackageMetadata, RequestFailure>
+
+export function decodeDownloadPoint(
+  body: string,
+  expectedPackageName: string,
+  expectedPeriod: DownloadPeriod,
+): Result<DownloadPoint, RequestFailure>
+
+export function decodeDownloadBulkResponse(
+  body: string,
+  expectedPackageNames: readonly string[],
+  expectedPeriod: DownloadPeriod,
+): Result<readonly DownloadPoint[], RequestFailure>
+
+export function decodeGitHubRepository(
+  body: string,
+  expectedFullName: string,
+): Result<GitHubRepositoryData, RequestFailure>
+```
+
+## 7. HTTP 与限流设计
+
+### 7.1 请求类型
+
+```ts
+export interface HttpHeader {
+  name: string
+  value: string
+}
+
+export interface HttpRequest {
+  host: ApiHost
+  method: 'GET'
+  url: string
+  headers: readonly HttpHeader[]
+  timeoutMs: number
+}
+
+export type ApiHost
+  = | 'replication'
+    | 'npm-registry'
+    | 'npm-downloads'
+    | 'github'
+```
+
+使用 Header 数组而不是带宽泛 value 类型的对象。
+
+### 7.2 Host 策略
+
+```ts
+export interface HostPolicy {
+  host: ApiHost
+  concurrency: number
+  intervalMs: number
+  intervalCap: number
+  requestTimeoutMs: number
+  maxAttemptsPerRun: number
+  circuitBreakerThreshold: number
+  circuitBreakerPauseMs: number
+}
+```
+
+建议初始值：
+
+| Host | 并发 | intervalCap / interval | 超时 |
+|---|---:|---:|---:|
+| Replication | 1 | 2 / 1000ms | 30s |
+| npm Registry | 3 | 5 / 1000ms | 30s |
+| npm Downloads | 1 | 1 / 750ms | 30s |
+| GitHub | 2 | 2 / 1000ms | 30s |
+
+这些是客户端保守起点，不是服务端承诺。Host Scheduler 必须能够在 429 或 rate-limit 下降时动态暂停。
+
+### 7.3 重试分类
+
+可重试：
+
+```text
+网络连接失败
+请求超时
+HTTP 408
+HTTP 425
+HTTP 429
+HTTP 500-599
+GitHub 403 且 x-ratelimit-remaining=0
+```
+
+不可重试并立即失败：
+
+```text
+HTTP 400
+HTTP 401
+HTTP 403 且不是 rate limit
+HTTP 404
+HTTP 410
+HTTP 422
+Schema 校验失败
+请求目标与响应实体不一致
+```
+
+404 的严格处理：
+
+- Replication 快照中存在包，但 npm `/latest` 返回 404：本轮失败，重新读取 Replication changes 后重跑，不能跳过。
+- metadata 存在 GitHub URL，但 GitHub 返回 404：本轮失败，不能把 Stars 写为 0。
+- Downloads 单包最终返回缺失或 404：本轮失败。
+
+退避顺序：
+
+```text
+1s → 2s → 4s → 8s → 16s → 30s → 60s
+```
+
+每次延迟乘以 0.5 到 1.5 的随机抖动。有 `Retry-After` 时以服务端值为准。GitHub `x-ratelimit-remaining=0` 时等待到 `x-ratelimit-reset + 5s`。
+
+所有重试必须重新提交给相同 Host Scheduler，确保重试也受限速控制。
+
+### 7.4 请求函数
+
+```ts
+export function sendOnce(
+  request: HttpRequest,
+): Promise<Result<HttpSuccess, RequestFailure>>
+
+export function executeScheduled(
+  request: HttpRequest,
+  policy: HostPolicy,
+): Promise<Result<HttpSuccess, RequestFailure>>
+
+export function calculateRetryDelay(
+  failure: RequestFailure,
+  attempt: number,
+  nowEpochMs: number,
+): Result<number, RequestFailure>
+```
+
+`sendOnce` 不重试；`executeScheduled` 是唯一允许实施重试的位置。
+
+## 8. 阶段一：Replication 全量扫描
+
+### 8.1 前缀范围
+
+每个定义请求：
+
+```text
+startkey=JSON.stringify(prefix)
+endkey=JSON.stringify(prefix + "\uFFF0")
+limit=1000
+```
+
+后续页面使用上一页最后一个 key 作为 startkey。因为 startkey 包含边界：
+
+- 后续页请求 `PAGE_SIZE + 1`。
+- 第一条等于上页 cursor 时才移除它。
+- 第一条不等于 cursor 时不能盲目 skip，避免 cursor 恰好被删除后漏掉下一条。
+
+### 8.2 扫描函数
+
+```ts
+export function fetchReplicationInfo(): Promise<Result<ReplicationInfo, RequestFailure>>
+
+export function fetchReplicationPage(
+  definition: PluginDefinition,
+  cursor: Presence<string>,
+): Promise<Result<ReplicationPage, RequestFailure>>
+
+export function collectPrefixPackages(
+  definition: PluginDefinition,
+): Promise<Result<readonly PackageTarget[], RequestFailure>>
+
+export function fetchChangesThrough(
+  startSequence: number,
+  endSequence: number,
+): Promise<Result<readonly ReplicationChange[], RequestFailure>>
+
+export function createReplicationSnapshot(
+  definitions: readonly PluginDefinition[],
+): Promise<Result<ReplicationSnapshot, RequestFailure>>
+```
+
+`createReplicationSnapshot` 算法：
+
+1. 读取 `startSequence`。
+2. 顺序扫描全部前缀。
+3. 读取 `endSequence`。
+4. 获取 `(startSequence, endSequence]` 内全部 changes。
+5. 对新增和更新记录 upsert，对 deleted 记录删除。
+6. 按 package name 去重。
+7. 验证每个结果都满足对应前缀。
+8. 排序后返回不可变 `ReplicationSnapshot`。
+
+## 9. 阶段二：每日全量 Package Metadata
+
+每日必须对阶段一的每个包发起检查。
+
+请求 URL：
+
+```text
+https://registry.npmjs.org/{encodeURIComponent(packageName)}/latest
+```
+
+请求规则：
+
+- 本地有上次成功实体且保存了 `Last-Modified`：发送 `If-Modified-Since`。
+- 没有缓存实体或没有 validator：发送普通 GET，必须得到 200。
+- 200：解析并保存新实体与新的 `Last-Modified`。
+- 304：必须验证缓存 package name、缓存 hash 和请求目标一致，然后记录 `response-304`。
+- 304 但缓存不存在：Invariant Failure。
+- 其他状态按统一错误策略处理。
+
+函数：
+
+```ts
+export function createPackageMetadataRequest(
+  target: PackageTarget,
+  cache: Presence<PackageMetadataCache>,
+): HttpRequest
+
+export function fetchPackageMetadata(
+  target: PackageTarget,
+  cache: Presence<PackageMetadataCache>,
+): Promise<Result<PackageMetadataRecord, RequestFailure>>
+
+export function fetchAllPackageMetadata(
+  snapshot: ReplicationSnapshot,
+  caches: readonly PackageMetadataCache[],
+): Promise<Result<readonly PackageMetadataRecord[], RequestFailure>>
+```
+
+完整性条件：
+
+```text
+metadata package-name 集合 === replication package-name 集合
+```
+
+任何包失败都会使阶段失败。
+
+## 10. 阶段三：每日全量 Downloads
+
+### 10.1 先锚定统计周期
+
+禁止在本地猜测 npm 的最新完整统计日。先用一个固定存在的 anchor 包向 npm 查询：
+
+```text
+GET https://api.npmjs.org/downloads/point/last-day/npm
+GET https://api.npmjs.org/downloads/point/last-month/npm
+```
+
+从响应取得：
+
+```text
+daily.start
+daily.end
+monthly.start
+monthly.end
+```
+
+然后把它们转换为本轮固定 period：
+
+```text
+daily apiPeriod   = daily.start
+monthly apiPeriod = monthly.start + ":" + monthly.end
+```
+
+本轮后续所有包都使用显式日期，不再使用 `last-day` 和 `last-month`，避免任务跨 UTC 日期边界后出现周期不一致。
+
+函数：
+
+```ts
+export function resolveDownloadPeriods(): Promise<
+  Result<readonly [DownloadPeriod, DownloadPeriod], RequestFailure>
+>
+```
+
+### 10.2 构建非 scoped bulk
+
+约束同时满足：
+
+- 每批最多 100 个包，低于官方 128 上限。
+- 编码后的完整 URL 最长 7000 字符。
+- 最后一批只有一个包时，按单包响应处理，不能套用 bulk schema。
+
+```ts
+export function createDownloadBatches(
+  packageNames: readonly string[],
+  period: DownloadPeriod,
+  maximumBatchSize: number,
+  maximumUrlLength: number,
+): Result<readonly DownloadBatch[], RequestFailure>
+```
+
+### 10.3 Scoped 包
+
+scoped 包单独请求，并编码 `/`：
+
+```text
+@rollup/plugin-alias
+→ %40rollup%2Fplugin-alias
+```
+
+每天每个 scoped 包发送两次请求：daily 一次，monthly 一次。
+
+### 10.4 批次完整性
+
+```ts
+export function fetchDownloadBatch(
+  batch: DownloadBatch,
+): Promise<Result<CompletedDownloadBatch, RequestFailure>>
+
+export function fetchAllDownloads(
+  packageNames: readonly string[],
+  dailyPeriod: DownloadPeriod,
+  monthlyPeriod: DownloadPeriod,
+): Promise<Result<readonly PackageDownloads[], RequestFailure>>
+```
+
+Decoder 必须验证：
+
+- 请求包名集合与响应包名集合完全相等。
+- 响应对象内部的 `package` 与外层 key 相等。
+- 所有 start/end 与本轮固定 period 相等。
+- downloads 是非负整数。
+- daily 和 monthly 最终都覆盖全部包。
+
+如果 bulk 缺少 key，整个 batch 失败。允许把该 batch 二分后重新提交，以判断是 URL 长度、单个包还是临时服务端问题；二分是诊断与重试策略，不允许把缺失包删除。
+
+## 11. 阶段四：每日全量 GitHub 条件检查
+
+### 11.1 Repository 解析
+
+支持：
+
+```text
+https://github.com/owner/repo
+git+https://github.com/owner/repo.git
+git://github.com/owner/repo.git
+git@github.com:owner/repo.git
+github:owner/repo
+owner/repo
+```
+
+优先级：
+
+1. `repository`
+2. `homepage`
+3. `bugsUrl`
+
+```ts
+export function extractGitHubTarget(
+  metadata: PackageMetadata,
+): Result<PackageGitHubTarget, RequestFailure>
+
+export function collectPackageGitHubTargets(
+  metadataRecords: readonly PackageMetadataRecord[],
+): Result<readonly PackageGitHubTarget[], RequestFailure>
+
+export function collectUniqueGitHubTargets(
+  packageTargets: readonly PackageGitHubTarget[],
+): Result<readonly GitHubRepositoryTarget[], RequestFailure>
+```
+
+没有 GitHub 链接返回 `kind: 'absent'`。字段明显声明为 GitHub 链接但格式无法解析时返回 invariant failure，不能按 absent 处理。
+
+### 11.2 条件请求
+
+请求头：
+
+```text
+Authorization: Bearer <token>
+Accept: application/vnd.github+json
+X-GitHub-Api-Version: 2022-11-28
+If-None-Match: <etag>
+```
+
+`If-None-Match` 仅在存在完整缓存实体和 ETag 时发送。
+
+```ts
+export function createGitHubRequest(
+  target: GitHubRepositoryTarget,
+  cache: Presence<GitHubRepositoryCache>,
+  token: string,
+): Result<HttpRequest, RequestFailure>
+
+export function fetchGitHubRepository(
+  target: GitHubRepositoryTarget,
+  cache: Presence<GitHubRepositoryCache>,
+  token: string,
+): Promise<Result<GitHubRepositoryRecord, RequestFailure>>
+
+export function fetchAllGitHubRepositories(
+  targets: readonly GitHubRepositoryTarget[],
+  caches: readonly GitHubRepositoryCache[],
+  token: string,
+): Promise<Result<readonly GitHubRepositoryRecord[], RequestFailure>>
+
+export function mapGitHubRecordsToPackages(
+  packageTargets: readonly PackageGitHubTarget[],
+  repositoryRecords: readonly GitHubRepositoryRecord[],
+): Result<readonly PackageGitHubData[], RequestFailure>
+```
+
+规则：
+
+- 200：解析实体，要求存在 ETag，然后更新缓存。
+- 304：缓存必须存在、ETag 必须与请求值一致、hash 必须通过校验。
+- 403/429：读取 Retry-After 和 rate-limit headers。
+- `remaining=0`：暂停到 reset 后再请求。
+- 404：存在 GitHub 链接却无法获取仓库，阶段失败。
+- 相同 fullName 只请求一次，再映射回所有 package。
+
+完整性条件：
+
+```text
+唯一 GitHub repository 集合 === 成功 GitHub record 集合
+```
+
+## 12. 阶段五：构建并发布完整快照
+
+### 12.1 全局集合校验
+
+```ts
+export function validateCompleteSnapshot(
+  replication: ReplicationSnapshot,
+  metadata: readonly PackageMetadataRecord[],
+  downloads: readonly PackageDownloads[],
+  github: readonly PackageGitHubData[],
+  dailyPeriod: DownloadPeriod,
+  monthlyPeriod: DownloadPeriod,
+  startedAt: string,
+  completedAt: string,
+): Result<CompletePluginSnapshot, RequestFailure>
+```
+
+必须验证：
+
+```text
+Replication packages == Metadata packages
+Replication packages == Downloads packages
+Replication packages == Package GitHub mapping packages
+GitHub targets == GitHub responses
+每个包恰好一个 daily point
+每个包恰好一个 monthly point
+所有 daily start/end 完全一致
+所有 monthly start/end 完全一致
+没有重复输出路径
+没有 pending task
+没有 retry task
+```
+
+### 12.2 发布
+
+```ts
+export function renderSnapshotEntry(
+  entry: PluginSnapshotEntry,
+): Result<string, RequestFailure>
+
+export function writeSnapshotToStage(
+  snapshot: CompletePluginSnapshot,
+): Promise<Result<string, RequestFailure>>
+
+export function publishStage(
+  stagePath: string,
+  snapshot: CompletePluginSnapshot,
+): Promise<Result<PublishedSnapshot, RequestFailure>>
+
+export interface PublishedSnapshot {
+  snapshotId: string
+  publishedPath: string
+  publishedAt: string
+}
+```
+
+发布顺序：
+
+1. 在独立 staging 目录生成全部文件。
+2. 重新统计文件数并与 snapshot entry 数量比较。
+3. 对全部文件执行内容解析和 schema 校验。
+4. 写入 snapshot manifest，状态为 complete。
+5. 使用目录 rename 完成原子切换。
+6. 发布成功后清理旧目录。
+
+请求失败时不创建正式目录，不覆盖旧目录。保留旧目录只是保持上一个已发布快照存在，不能把它标记为本次同步成功。
+
+## 13. 持久化状态设计
+
+条件请求和断点续传要求持久化存储。推荐 SQLite，而不是数千个零散临时 JSON。
+
+### 13.1 表
+
+```text
+sync_runs
+replication_packages
+package_metadata_cache
+download_points_working
+github_repository_cache
+sync_tasks
+published_snapshots
+```
+
+### 13.2 Run 状态
+
+```ts
+export type ActiveSyncStage
+  = | 'replication'
+    | 'metadata'
+    | 'downloads'
+    | 'github'
+    | 'validation'
+    | 'publishing'
+
+export interface ReplicationBounds {
+  startSequence: number
+  endSequence: number
+}
+
+export interface SyncRunIdentity {
+  runId: string
+  businessDate: string
+  startedAt: string
+  updatedAt: string
+}
+
+export type SyncRun
+  = | SyncRunIdentity & {
+    status: 'running'
+    stage: ActiveSyncStage
+    replication: Presence<ReplicationBounds>
+  }
+  | SyncRunIdentity & {
+    status: 'complete'
+    completedAt: string
+    replication: ReplicationBounds
+  }
+  | SyncRunIdentity & {
+    status: 'failed'
+    failedAt: string
+    failedStage: ActiveSyncStage
+    replication: Presence<ReplicationBounds>
+    failureMessage: string
+  }
+```
+
+### 13.3 Task 状态
+
+```ts
+export interface SyncTaskIdentity {
+  runId: string
+  source: ApiHost
+  taskKey: string
+}
+
+export type SyncTask
+  = | SyncTaskIdentity & {
+    status: 'pending'
+    attempt: 0
+  }
+  | SyncTaskIdentity & {
+    status: 'running'
+    attempt: number
+    startedAt: string
+  }
+  | SyncTaskIdentity & {
+    status: 'retry-wait'
+    attempt: number
+    nextAttemptAt: string
+    failure: RequestFailure
+  }
+  | SyncTaskIdentity & {
+    status: 'success'
+    attempt: number
+    completedAt: string
+    responseStatus: number
+  }
+  | SyncTaskIdentity & {
+    status: 'failed'
+    attempt: number
+    failedAt: string
+    failure: RequestFailure
+  }
+```
+
+每个成功请求必须在事务中同时完成：
+
+1. 写入解析后的业务实体。
+2. 写入 validator 和 response hash。
+3. 将 task 状态更新为 success。
+
+不能先把 task 标记成功，再异步保存数据。
+
+### 13.4 Store 接口
+
+```ts
+export interface StoredEntityCount {
+  count: number
+}
+
+export interface StateStore {
+  readPackageMetadataCaches: () => Promise<
+    Result<readonly PackageMetadataCache[], RequestFailure>
+  >
+  readGitHubCaches: () => Promise<
+    Result<readonly GitHubRepositoryCache[], RequestFailure>
+  >
+  saveReplicationSnapshot: (
+    runId: string,
+    snapshot: ReplicationSnapshot,
+  ) => Promise<Result<StoredEntityCount, RequestFailure>>
+  savePackageMetadata: (
+    runId: string,
+    records: readonly PackageMetadataRecord[],
+  ) => Promise<Result<StoredEntityCount, RequestFailure>>
+  saveDownloads: (
+    runId: string,
+    records: readonly PackageDownloads[],
+  ) => Promise<Result<StoredEntityCount, RequestFailure>>
+  saveGitHubRepositories: (
+    runId: string,
+    records: readonly GitHubRepositoryRecord[],
+  ) => Promise<Result<StoredEntityCount, RequestFailure>>
+  updateRun: (run: SyncRun) => Promise<Result<SyncRun, RequestFailure>>
+  updateTask: (task: SyncTask) => Promise<Result<SyncTask, RequestFailure>>
+}
+```
+
+每个 save 方法必须开启数据库事务，在同一事务内写业务实体、缓存 validator、response hash 和对应 task 成功状态。返回的 `count` 必须与输入集合长度一致，否则产生 storage failure。
+
+## 14. Pipeline 函数
+
+```ts
+export interface PipelineClock {
+  nowIso: () => string
+}
+
+export interface PipelineDependencies {
+  store: StateStore
+  clock: PipelineClock
+  replicationPolicy: HostPolicy
+  npmRegistryPolicy: HostPolicy
+  npmDownloadsPolicy: HostPolicy
+  githubPolicy: HostPolicy
+  githubToken: string
+}
+
+export function runDailyPluginPipeline(
+  dependencies: PipelineDependencies,
+  definitions: readonly PluginDefinition[],
+  startedAt: string,
+): Promise<Result<CompletePluginSnapshot, RequestFailure>>
+```
+
+严格编排伪代码：
+
+```ts
+async function runDailyPluginPipeline(
+  dependencies: PipelineDependencies,
+  definitions: readonly PluginDefinition[],
+  startedAt: string,
+): Promise<Result<CompletePluginSnapshot, RequestFailure>> {
+  const replication = await createReplicationSnapshot(definitions)
+  if (!replication.ok)
+    return replication
+
+  const metadataCaches = await dependencies.store.readPackageMetadataCaches()
+  if (!metadataCaches.ok)
+    return metadataCaches
+
+  const metadata = await fetchAllPackageMetadata(
+    replication.value,
+    metadataCaches.value,
+  )
+  if (!metadata.ok)
+    return metadata
+
+  const periods = await resolveDownloadPeriods()
+  if (!periods.ok)
+    return periods
+
+  const downloads = await fetchAllDownloads(
+    replication.value.packages.map(item => item.packageName),
+    periods.value[0],
+    periods.value[1],
+  )
+  if (!downloads.ok)
+    return downloads
+
+  const packageTargets = collectPackageGitHubTargets(metadata.value)
+  if (!packageTargets.ok)
+    return packageTargets
+
+  const repositoryTargets = collectUniqueGitHubTargets(packageTargets.value)
+  if (!repositoryTargets.ok)
+    return repositoryTargets
+
+  const githubCaches = await dependencies.store.readGitHubCaches()
+  if (!githubCaches.ok)
+    return githubCaches
+
+  const githubRecords = await fetchAllGitHubRepositories(
+    repositoryTargets.value,
+    githubCaches.value,
+    dependencies.githubToken,
+  )
+  if (!githubRecords.ok)
+    return githubRecords
+
+  const github = mapGitHubRecordsToPackages(
+    packageTargets.value,
+    githubRecords.value,
+  )
+  if (!github.ok)
+    return github
+
+  const snapshot = validateCompleteSnapshot(
+    replication.value,
+    metadata.value,
+    downloads.value,
+    github.value,
+    periods.value[0],
+    periods.value[1],
+    startedAt,
+    dependencies.clock.nowIso(),
+  )
+  if (!snapshot.ok)
+    return snapshot
+
+  const stage = await writeSnapshotToStage(snapshot.value)
+  if (!stage.ok)
+    return stage
+
+  const published = await publishStage(stage.value, snapshot.value)
+  if (!published.ok)
+    return published
+
+  return { ok: true, value: snapshot.value }
+}
+```
+
+开始与结束时间都必须来自 `clock.ts` 注入的单一时钟依赖，并在构造快照时校验为 ISO 8601 UTC 时间。
+
+## 15. 每日请求规模
+
+假设命中约 6655 个包，其中 scoped 包约 30 个，GitHub 唯一仓库数为 `R`：
+
+```text
+Replication：约 10-15 次
+Package metadata：6655 次条件请求
+Downloads 非 scoped：ceil(6625 / 100) × 2 ≈ 134 次
+Downloads scoped：30 × 2 = 60 次
+Downloads 周期锚定：2 次
+GitHub：R 次条件请求
+```
+
+Package metadata 和 GitHub 两个阶段每天都会覆盖全量目标：
+
+- 未变化的 metadata 可由 npm 返回 304。
+- 未变化的 GitHub repository 可由 GitHub 返回 304。
+- 304 是服务端确认后的有效响应，不是错误兜底。
+- Downloads 没有使用昨日值的条件分支，每天必须拿到当期完整 200 响应。
+
+首次执行没有条件请求缓存：
+
+- metadata 全部返回 200，耗时和流量最高。
+- GitHub 全部返回 200；如果唯一仓库数超过 Token 当前剩余额度，必须等待 rate-limit reset 后继续。
+
+稳定运行后仍发送全量检查，但 metadata 和 GitHub 的多数响应体可由 304 避免重复传输。
+
+## 16. 验收标准
+
+### Replication
+
+- 每个前缀至少覆盖一页、末页和 cursor 边界测试。
+- cursor 记录被删除时不会漏掉下一条。
+- changes 中新增、更新和删除均正确应用。
+- 相同包不会重复出现。
+
+### Metadata
+
+- 普通包与 scoped 包 URL 编码正确。
+- 稀疏包的缺失字段规范化为 `Presence<T>` 的 absent 分支。
+- 200 和 304 都有测试。
+- 304 缓存缺失时必须失败。
+- package name 不一致时必须失败。
+
+### Downloads
+
+- bulk、单包、scoped 单包分别测试。
+- 100 包边界、7000 字符边界和单包尾批分别测试。
+- 缺 key、额外 key、period 不一致、负数、非整数全部失败。
+- 真实 `downloads: 0` 保留为 0。
+- 请求失败不会产生 0。
+
+### GitHub
+
+- repository 各种 URL 格式均有测试。
+- 多包同仓库只发一个请求。
+- 200、304、403 rate limit、429 和 404 分别测试。
+- 304 的 ETag 或缓存 hash 不一致时必须失败。
+- GitHub API 失败不会产生 Stars 0。
+
+### Snapshot
+
+- 四个 package 集合必须完全相等。
+- 任意一个任务不是 success 时禁止发布。
+- staging 文件数和 snapshot entries 数相等。
+- 发布失败能够恢复原正式目录。
+- 成功快照中的 downloads 与已识别 GitHub 仓库的 stars 都是确定值。
+
+## 17. 最终执行语义
+
+每天一次完整 Run 的成功定义是：
+
+```text
+Replication 全量完成
+AND 全量 metadata 200/304 检查完成
+AND 全量 daily Downloads 完成
+AND 全量 monthly Downloads 完成
+AND 全量 GitHub repository 200/304 检查完成
+AND 全局集合与周期校验通过
+AND staging 发布成功
+```
+
+任何一项不成立，本次 Run 必须是 failed 或 retry-wait，不能是 complete。调度系统可以稍后继续同一个 Run；只有获得全部必要数据后，才能发布该业务日期对应的完整快照。

--- a/packages/generate/.gitignore
+++ b/packages/generate/.gitignore
@@ -1,0 +1,2 @@
+.sync-work/
+snapshots/

--- a/packages/generate/package.json
+++ b/packages/generate/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@vuejs-community/generate",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "generate": "tsx src/scripts/generate-plugin-names.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^26.4.0",
+    "@vuejs-community/tsconfig": "workspace:*",
+    "p-queue": "^9.3.3",
+    "tsx": "^4.23.13",
+    "typescript": "^6.0.3",
+    "zod": "^4.5.4"
+  }
+}

--- a/packages/generate/src/generate-plugin/clock.ts
+++ b/packages/generate/src/generate-plugin/clock.ts
@@ -1,0 +1,17 @@
+// 时钟：本轮同步的唯一时间上下文，各阶段不允许重复读取当前日期。
+
+export interface PipelineClock {
+  nowIso: () => string
+}
+
+export function createSystemClock(): PipelineClock {
+  return {
+    nowIso: () => new Date().toISOString(),
+  }
+}
+
+export function isValidIsoUtcTimestamp(value: string): boolean {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value))
+    return false
+  return Number.isFinite(Date.parse(value))
+}

--- a/packages/generate/src/generate-plugin/contracts.ts
+++ b/packages/generate/src/generate-plugin/contracts.ts
@@ -337,114 +337,16 @@ export interface PublishedSnapshot {
 }
 
 // ---------------------------------------------------------------------------
-// 同步 Run 与 Task 状态
+// 跨 Run 缓存存储接口（JSON 文件实现）
+// 缓存文件保存 metadata Last-Modified 与 GitHub ETag 校验器，
+// 使每日全量检查的多数响应退化为 304；run 内任务状态不持久化。
 // ---------------------------------------------------------------------------
 
-export type ActiveSyncStage
-  = | 'replication'
-    | 'metadata'
-    | 'downloads'
-    | 'github'
-    | 'validation'
-    | 'publishing'
-
-export interface ReplicationBounds {
-  startSequence: number
-  endSequence: number
-}
-
-export interface SyncRunIdentity {
-  runId: string
-  businessDate: string
-  startedAt: string
-  updatedAt: string
-}
-
-export type SyncRun
-  = | SyncRunIdentity & {
-    status: 'running'
-    stage: ActiveSyncStage
-    replication: Presence<ReplicationBounds>
-  }
-  | SyncRunIdentity & {
-    status: 'complete'
-    completedAt: string
-    replication: ReplicationBounds
-  }
-  | SyncRunIdentity & {
-    status: 'failed'
-    failedAt: string
-    failedStage: ActiveSyncStage
-    replication: Presence<ReplicationBounds>
-    failureMessage: string
-  }
-
-export type SyncTaskStatus = 'pending' | 'running' | 'retry-wait' | 'success' | 'failed'
-
-export interface SyncTaskIdentity {
-  runId: string
-  source: ApiHost
-  taskKey: string
-}
-
-export type SyncTask
-  = | SyncTaskIdentity & {
-    status: 'pending'
-    attempt: 0
-  }
-  | SyncTaskIdentity & {
-    status: 'running'
-    attempt: number
-    startedAt: string
-  }
-  | SyncTaskIdentity & {
-    status: 'retry-wait'
-    attempt: number
-    nextAttemptAt: string
-    failure: RequestFailure
-  }
-  | SyncTaskIdentity & {
-    status: 'success'
-    attempt: number
-    completedAt: string
-    responseStatus: number
-  }
-  | SyncTaskIdentity & {
-    status: 'failed'
-    attempt: number
-    failedAt: string
-    failure: RequestFailure
-  }
-
-export interface StoredTaskSummary {
-  source: ApiHost
-  taskKey: string
-  status: SyncTaskStatus
-}
-
-export interface StoredEntityCount {
-  count: number
-}
-
-// ---------------------------------------------------------------------------
-// 持久化存储接口
-// ---------------------------------------------------------------------------
-
-export interface StateStore {
-  readPackageMetadataCaches: () => Promise<Result<readonly PackageMetadataCache[], RequestFailure>>
-  readGitHubCaches: () => Promise<Result<readonly GitHubRepositoryCache[], RequestFailure>>
-  readWorkingDownloadPoints: (runId: string) => Promise<Result<readonly DownloadPoint[], RequestFailure>>
-  readReplicationSnapshot: (runId: string) => Promise<Result<Presence<readonly PackageTarget[]>, RequestFailure>>
-  readTaskSummaries: (runId: string) => Promise<Result<readonly StoredTaskSummary[], RequestFailure>>
-  findResumableRun: () => Promise<Result<Presence<SyncRun>, RequestFailure>>
-  createRun: (run: SyncRun) => Promise<Result<SyncRun, RequestFailure>>
-  updateRun: (run: SyncRun) => Promise<Result<SyncRun, RequestFailure>>
-  saveReplicationSnapshot: (runId: string, snapshot: ReplicationSnapshot) => Promise<Result<StoredEntityCount, RequestFailure>>
-  savePackageMetadata: (runId: string, outcomes: readonly PackageMetadataOutcome[]) => Promise<Result<StoredEntityCount, RequestFailure>>
-  saveDownloads: (runId: string, records: readonly PackageDownloads[]) => Promise<Result<StoredEntityCount, RequestFailure>>
-  saveGitHubRepositories: (runId: string, outcomes: readonly GitHubRepositoryOutcome[]) => Promise<Result<StoredEntityCount, RequestFailure>>
-  recordTaskSuccess: (runId: string, source: ApiHost, taskKey: string, attempt: number, responseStatus: number) => Promise<Result<StoredTaskSummary, RequestFailure>>
-  recordTaskFailure: (runId: string, source: ApiHost, taskKey: string, attempt: number, failure: RequestFailure) => Promise<Result<StoredTaskSummary, RequestFailure>>
-  savePublishedSnapshot: (published: PublishedSnapshot, snapshot: CompletePluginSnapshot) => Promise<Result<PublishedSnapshot, RequestFailure>>
+export interface CacheStore {
+  readMetadataCaches: () => Result<readonly PackageMetadataCache[], RequestFailure>
+  readGitHubCaches: () => Result<readonly GitHubRepositoryCache[], RequestFailure>
+  saveMetadataCache: (cache: PackageMetadataCache) => Result<boolean, RequestFailure>
+  saveGitHubCache: (cache: GitHubRepositoryCache) => Result<boolean, RequestFailure>
+  flush: () => Result<boolean, RequestFailure>
   close: () => void
 }

--- a/packages/generate/src/generate-plugin/contracts.ts
+++ b/packages/generate/src/generate-plugin/contracts.ts
@@ -1,0 +1,450 @@
+// 领域契约：所有规范化类型与 Result 类型。业务层不允许以特殊值表达缺失、失败或尚未执行。
+
+export type Result<T, E>
+  = | { ok: true, value: T }
+    | { ok: false, error: E }
+
+export type Presence<T>
+  = | { state: 'present', value: T }
+    | { state: 'absent' }
+
+export function ok<T>(value: T): Result<T, never> {
+  return { ok: true, value }
+}
+
+export function failure<E>(error: E): Result<never, E> {
+  return { ok: false, error }
+}
+
+export function present<T>(value: T): Presence<T> {
+  return { state: 'present', value }
+}
+
+export function absent<T>(): Presence<T> {
+  return { state: 'absent' }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP 契约
+// ---------------------------------------------------------------------------
+
+export type ApiHost = 'replication' | 'npm-registry' | 'npm-downloads' | 'github'
+
+export type RequestFailure
+  = | { kind: 'network', message: string }
+    | { kind: 'timeout', timeoutMs: number }
+    | {
+      kind: 'http'
+      status: number
+      body: string
+      retryAfterMs: Presence<number>
+      rateLimitRemaining: Presence<number>
+      rateLimitResetAt: Presence<number>
+    }
+    | { kind: 'schema', issues: readonly string[] }
+    | { kind: 'invariant', message: string }
+    | { kind: 'storage', operation: string, message: string }
+    | { kind: 'publish', operation: string, message: string }
+
+export interface ResponseMetadata {
+  status: number
+  etag: Presence<string>
+  lastModified: Presence<string>
+  retryAfterMs: Presence<number>
+  rateLimitLimit: Presence<number>
+  rateLimitRemaining: Presence<number>
+  rateLimitUsed: Presence<number>
+  rateLimitResetAt: Presence<number>
+}
+
+export type HttpSuccess
+  = | {
+    kind: 'body'
+    body: string
+    metadata: ResponseMetadata
+  }
+  | {
+    kind: 'not-modified'
+    metadata: ResponseMetadata
+  }
+
+export interface HttpHeader {
+  name: string
+  value: string
+}
+
+export interface HttpRequest {
+  host: ApiHost
+  method: 'GET'
+  url: string
+  headers: readonly HttpHeader[]
+  timeoutMs: number
+}
+
+export interface HostPolicy {
+  host: ApiHost
+  concurrency: number
+  intervalMs: number
+  intervalCap: number
+  requestTimeoutMs: number
+  maxAttemptsPerRun: number
+  circuitBreakerThreshold: number
+  circuitBreakerPauseMs: number
+}
+
+// ---------------------------------------------------------------------------
+// Plugin 定义
+// ---------------------------------------------------------------------------
+
+export type PluginType
+  = | 'vite-plugin'
+    | 'rollup-plugin'
+    | 'rolldown-plugin'
+    | 'unplugin'
+
+export interface PluginDefinition {
+  directory: 'vite' | 'rollup' | 'rolldown' | 'unplugin'
+  packageNamePrefix: string
+  type: PluginType
+  icon: string
+}
+
+// ---------------------------------------------------------------------------
+// Replication
+// ---------------------------------------------------------------------------
+
+export interface ReplicationInfo {
+  databaseName: string
+  engine: string
+  documentCount: number
+  updateSequence: number
+}
+
+export interface ReplicationIndexRow {
+  packageName: string
+  key: string
+  revision: string
+}
+
+export interface ReplicationPage {
+  totalRows: number
+  offset: number
+  rows: readonly ReplicationIndexRow[]
+}
+
+export interface ReplicationChange {
+  sequence: number
+  packageName: string
+  revision: string
+  deleted: boolean
+}
+
+export interface ReplicationChangesPage {
+  lastSequence: number
+  changes: readonly ReplicationChange[]
+}
+
+export interface PackageTarget {
+  packageName: string
+  revision: string
+  definition: PluginDefinition
+}
+
+export interface ReplicationSnapshot {
+  startSequence: number
+  endSequence: number
+  packages: readonly PackageTarget[]
+}
+
+// ---------------------------------------------------------------------------
+// Package metadata
+// ---------------------------------------------------------------------------
+
+export type NpmRepository
+  = | {
+    kind: 'string'
+    value: string
+  }
+  | {
+    kind: 'object'
+    url: string
+    type: Presence<string>
+    directory: Presence<string>
+  }
+
+export interface PackageMetadata {
+  name: string
+  version: string
+  description: Presence<string>
+  keywords: Presence<readonly string[]>
+  repository: Presence<NpmRepository>
+  homepage: Presence<string>
+  bugsUrl: Presence<string>
+  deprecated: Presence<string>
+}
+
+export interface PackageMetadataCache {
+  packageName: string
+  requestUrl: string
+  lastModified: Presence<string>
+  responseHash: string
+  metadata: PackageMetadata
+}
+
+export type PackageMetadataRecord
+  = | {
+    validation: 'response-200'
+    target: PackageTarget
+    metadata: PackageMetadata
+    cacheValidator: Presence<string>
+  }
+  | {
+    validation: 'response-304'
+    target: PackageTarget
+    metadata: PackageMetadata
+    cacheValidator: string
+  }
+
+export interface PackageMetadataOutcome {
+  record: PackageMetadataRecord
+  cache: PackageMetadataCache
+  attempts: number
+}
+
+// ---------------------------------------------------------------------------
+// Downloads
+// ---------------------------------------------------------------------------
+
+export type DownloadMetricKind = 'daily' | 'monthly'
+
+export interface DownloadPeriod {
+  kind: DownloadMetricKind
+  start: string
+  end: string
+  apiPeriod: string
+}
+
+export interface DownloadPoint {
+  packageName: string
+  downloads: number
+  start: string
+  end: string
+}
+
+export interface PackageDownloads {
+  packageName: string
+  daily: DownloadPoint
+  monthly: DownloadPoint
+}
+
+export interface DownloadBatch {
+  kind: DownloadMetricKind
+  period: DownloadPeriod
+  requestedPackageNames: readonly string[]
+  requestUrl: string
+}
+
+export interface CompletedDownloadBatch {
+  batch: DownloadBatch
+  points: readonly DownloadPoint[]
+}
+
+// ---------------------------------------------------------------------------
+// GitHub
+// ---------------------------------------------------------------------------
+
+export interface GitHubRepositoryTarget {
+  fullName: string
+  owner: string
+  repository: string
+}
+
+export type PackageGitHubTarget
+  = | {
+    kind: 'repository'
+    packageName: string
+    target: GitHubRepositoryTarget
+  }
+  | {
+    kind: 'absent'
+    packageName: string
+  }
+
+export interface GitHubRepositoryData {
+  fullName: string
+  htmlUrl: string
+  stars: number
+  archived: boolean
+  disabled: boolean
+}
+
+export interface GitHubRepositoryCache {
+  fullName: string
+  etag: string
+  responseHash: string
+  data: GitHubRepositoryData
+}
+
+export interface GitHubRepositoryRecord {
+  data: GitHubRepositoryData
+  etag: string
+  validation: 'response-200' | 'response-304'
+}
+
+export interface GitHubRepositoryOutcome {
+  record: GitHubRepositoryRecord
+  nextCache: Presence<GitHubRepositoryCache>
+  attempts: number
+}
+
+export type PackageGitHubData
+  = | {
+    kind: 'repository'
+    packageName: string
+    repository: GitHubRepositoryRecord
+  }
+  | {
+    kind: 'absent'
+    packageName: string
+  }
+
+// ---------------------------------------------------------------------------
+// 完整快照
+// ---------------------------------------------------------------------------
+
+export interface PluginSnapshotEntry {
+  target: PackageTarget
+  packageMetadata: PackageMetadataRecord
+  downloads: PackageDownloads
+  github: PackageGitHubData
+}
+
+export interface CompletePluginSnapshot {
+  snapshotId: string
+  startedAt: string
+  completedAt: string
+  replicationStartSequence: number
+  replicationEndSequence: number
+  dailyPeriod: DownloadPeriod
+  monthlyPeriod: DownloadPeriod
+  entries: readonly PluginSnapshotEntry[]
+}
+
+export interface PublishedSnapshot {
+  snapshotId: string
+  publishedPath: string
+  publishedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// 同步 Run 与 Task 状态
+// ---------------------------------------------------------------------------
+
+export type ActiveSyncStage
+  = | 'replication'
+    | 'metadata'
+    | 'downloads'
+    | 'github'
+    | 'validation'
+    | 'publishing'
+
+export interface ReplicationBounds {
+  startSequence: number
+  endSequence: number
+}
+
+export interface SyncRunIdentity {
+  runId: string
+  businessDate: string
+  startedAt: string
+  updatedAt: string
+}
+
+export type SyncRun
+  = | SyncRunIdentity & {
+    status: 'running'
+    stage: ActiveSyncStage
+    replication: Presence<ReplicationBounds>
+  }
+  | SyncRunIdentity & {
+    status: 'complete'
+    completedAt: string
+    replication: ReplicationBounds
+  }
+  | SyncRunIdentity & {
+    status: 'failed'
+    failedAt: string
+    failedStage: ActiveSyncStage
+    replication: Presence<ReplicationBounds>
+    failureMessage: string
+  }
+
+export type SyncTaskStatus = 'pending' | 'running' | 'retry-wait' | 'success' | 'failed'
+
+export interface SyncTaskIdentity {
+  runId: string
+  source: ApiHost
+  taskKey: string
+}
+
+export type SyncTask
+  = | SyncTaskIdentity & {
+    status: 'pending'
+    attempt: 0
+  }
+  | SyncTaskIdentity & {
+    status: 'running'
+    attempt: number
+    startedAt: string
+  }
+  | SyncTaskIdentity & {
+    status: 'retry-wait'
+    attempt: number
+    nextAttemptAt: string
+    failure: RequestFailure
+  }
+  | SyncTaskIdentity & {
+    status: 'success'
+    attempt: number
+    completedAt: string
+    responseStatus: number
+  }
+  | SyncTaskIdentity & {
+    status: 'failed'
+    attempt: number
+    failedAt: string
+    failure: RequestFailure
+  }
+
+export interface StoredTaskSummary {
+  source: ApiHost
+  taskKey: string
+  status: SyncTaskStatus
+}
+
+export interface StoredEntityCount {
+  count: number
+}
+
+// ---------------------------------------------------------------------------
+// 持久化存储接口
+// ---------------------------------------------------------------------------
+
+export interface StateStore {
+  readPackageMetadataCaches: () => Promise<Result<readonly PackageMetadataCache[], RequestFailure>>
+  readGitHubCaches: () => Promise<Result<readonly GitHubRepositoryCache[], RequestFailure>>
+  readWorkingDownloadPoints: (runId: string) => Promise<Result<readonly DownloadPoint[], RequestFailure>>
+  readReplicationSnapshot: (runId: string) => Promise<Result<Presence<readonly PackageTarget[]>, RequestFailure>>
+  readTaskSummaries: (runId: string) => Promise<Result<readonly StoredTaskSummary[], RequestFailure>>
+  findResumableRun: () => Promise<Result<Presence<SyncRun>, RequestFailure>>
+  createRun: (run: SyncRun) => Promise<Result<SyncRun, RequestFailure>>
+  updateRun: (run: SyncRun) => Promise<Result<SyncRun, RequestFailure>>
+  saveReplicationSnapshot: (runId: string, snapshot: ReplicationSnapshot) => Promise<Result<StoredEntityCount, RequestFailure>>
+  savePackageMetadata: (runId: string, outcomes: readonly PackageMetadataOutcome[]) => Promise<Result<StoredEntityCount, RequestFailure>>
+  saveDownloads: (runId: string, records: readonly PackageDownloads[]) => Promise<Result<StoredEntityCount, RequestFailure>>
+  saveGitHubRepositories: (runId: string, outcomes: readonly GitHubRepositoryOutcome[]) => Promise<Result<StoredEntityCount, RequestFailure>>
+  recordTaskSuccess: (runId: string, source: ApiHost, taskKey: string, attempt: number, responseStatus: number) => Promise<Result<StoredTaskSummary, RequestFailure>>
+  recordTaskFailure: (runId: string, source: ApiHost, taskKey: string, attempt: number, failure: RequestFailure) => Promise<Result<StoredTaskSummary, RequestFailure>>
+  savePublishedSnapshot: (published: PublishedSnapshot, snapshot: CompletePluginSnapshot) => Promise<Result<PublishedSnapshot, RequestFailure>>
+  close: () => void
+}

--- a/packages/generate/src/generate-plugin/definitions.ts
+++ b/packages/generate/src/generate-plugin/definitions.ts
@@ -1,0 +1,37 @@
+// Plugin 定义：包名前缀、归属目录、类型与图标。
+// 所有字段必填，不使用可选属性。
+
+import type { PluginDefinition } from './contracts'
+
+export const pluginDefinitions: readonly PluginDefinition[] = [
+  {
+    directory: 'vite',
+    packageNamePrefix: 'vite-plugin',
+    type: 'vite-plugin',
+    icon: 'logos:vitejs',
+  },
+  {
+    directory: 'rollup',
+    packageNamePrefix: 'rollup-plugin',
+    type: 'rollup-plugin',
+    icon: 'logos:rollupjs',
+  },
+  {
+    directory: 'rolldown',
+    packageNamePrefix: 'rolldown-plugin',
+    type: 'rolldown-plugin',
+    icon: 'logos:rolldown',
+  },
+  {
+    directory: 'unplugin',
+    packageNamePrefix: 'unplugin',
+    type: 'unplugin',
+    icon: 'lucide:plug',
+  },
+  {
+    directory: 'rollup',
+    packageNamePrefix: '@rollup/plugin-',
+    type: 'rollup-plugin',
+    icon: 'logos:rollupjs',
+  },
+]

--- a/packages/generate/src/generate-plugin/github-client.ts
+++ b/packages/generate/src/generate-plugin/github-client.ts
@@ -1,0 +1,237 @@
+// 阶段四：每日全量 GitHub 条件检查。
+// 相同仓库只请求一次；200 更新缓存并要求 ETag；304 必须与缓存 ETag/hash 一致；
+// 存在 GitHub 链接但 API 未成功时整个快照失败，绝不把 Stars 写为 0。
+
+import type { GitHubRepositoryCache, GitHubRepositoryOutcome, GitHubRepositoryRecord, GitHubRepositoryTarget, HttpHeader, HttpRequest, PackageGitHubData, PackageGitHubTarget, Presence, RequestFailure, Result, StateStore } from './contracts'
+import type { HostScheduler } from './host-scheduler'
+import {
+  absent,
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+import { executeScheduled } from './host-scheduler'
+import { decodeGitHubRepository } from './schemas'
+import { isValidResponseHash, sha256Hex } from './utils'
+
+const GITHUB_ENDPOINT = 'https://api.github.com'
+
+export interface GitHubClientDependencies {
+  scheduler: HostScheduler
+  store: StateStore
+  runId: string
+  token: string
+}
+
+export function createGitHubRequest(
+  target: GitHubRepositoryTarget,
+  cache: Presence<GitHubRepositoryCache>,
+  token: string,
+  timeoutMs: number,
+): HttpRequest {
+  const requestUrl = `${GITHUB_ENDPOINT}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repository)}`
+  const headers: HttpHeader[] = [
+    { name: 'Authorization', value: `Bearer ${token}` },
+    { name: 'Accept', value: 'application/vnd.github+json' },
+    { name: 'X-GitHub-Api-Version', value: '2022-11-28' },
+  ]
+  if (cache.state === 'present')
+    headers.push({ name: 'If-None-Match', value: cache.value.etag })
+  return {
+    host: 'github',
+    method: 'GET',
+    url: requestUrl,
+    headers,
+    timeoutMs,
+  }
+}
+
+function githubTaskKey(target: GitHubRepositoryTarget): string {
+  return target.fullName.toLowerCase()
+}
+
+export async function fetchGitHubRepository(
+  dependencies: GitHubClientDependencies,
+  target: GitHubRepositoryTarget,
+  cache: Presence<GitHubRepositoryCache>,
+): Promise<Result<GitHubRepositoryOutcome, RequestFailure>> {
+  const taskKey = githubTaskKey(target)
+  const request = createGitHubRequest(target, cache, dependencies.token, dependencies.scheduler.policy.requestTimeoutMs)
+  const scheduled = await executeScheduled(request, dependencies.scheduler)
+
+  if (!scheduled.ok) {
+    const recorded = await dependencies.store.recordTaskFailure(
+      dependencies.runId,
+      'github',
+      taskKey,
+      scheduled.error.attempts,
+      scheduled.error.failure,
+    )
+    if (!recorded.ok) {
+      console.error(`failed to record github task failure for "${taskKey}"`, scheduled.error.failure)
+      return failure(recorded.error)
+    }
+    return failure(scheduled.error.failure)
+  }
+
+  const { response, attempts } = scheduled.value
+
+  if (response.kind === 'not-modified') {
+    if (cache.state !== 'present') {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `github returned 304 for "${target.fullName}" without a local cache entity`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+    if (cache.value.fullName.toLowerCase() !== target.fullName.toLowerCase()) {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `github cache entity "${cache.value.fullName}" does not match the requested repository "${target.fullName}"`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+    if (!isValidResponseHash(cache.value.responseHash)) {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `github cache hash for "${target.fullName}" failed validation`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+
+    const record: GitHubRepositoryRecord = {
+      data: cache.value.data,
+      etag: cache.value.etag,
+      validation: 'response-304',
+    }
+    const saved = await dependencies.store.saveGitHubRepositories(dependencies.runId, [
+      { record, nextCache: absent<GitHubRepositoryCache>(), attempts },
+    ])
+    if (!saved.ok)
+      return failure(saved.error)
+    return ok({ record, nextCache: absent<GitHubRepositoryCache>(), attempts })
+  }
+
+  const decoded = decodeGitHubRepository(response.body, target.fullName)
+  if (!decoded.ok) {
+    await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, decoded.error)
+    return decoded
+  }
+  if (response.metadata.etag.state !== 'present') {
+    const failureInfo: RequestFailure = {
+      kind: 'invariant',
+      message: `github response for "${target.fullName}" does not carry an ETag validator`,
+    }
+    await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
+    return failure(failureInfo)
+  }
+
+  const etag = response.metadata.etag.value
+  const nextCache: GitHubRepositoryCache = {
+    fullName: decoded.value.fullName,
+    etag,
+    responseHash: sha256Hex(response.body),
+    data: decoded.value,
+  }
+  const record: GitHubRepositoryRecord = {
+    data: decoded.value,
+    etag,
+    validation: 'response-200',
+  }
+  const saved = await dependencies.store.saveGitHubRepositories(dependencies.runId, [
+    { record, nextCache: present(nextCache), attempts },
+  ])
+  if (!saved.ok)
+    return failure(saved.error)
+  return ok({ record, nextCache: present(nextCache), attempts })
+}
+
+export async function fetchAllGitHubRepositories(
+  dependencies: GitHubClientDependencies,
+  targets: readonly GitHubRepositoryTarget[],
+): Promise<Result<readonly GitHubRepositoryRecord[], RequestFailure>> {
+  const caches = await dependencies.store.readGitHubCaches()
+  if (!caches.ok)
+    return caches
+  const cacheMap = new Map(caches.value.map(entry => [entry.fullName.toLowerCase(), entry]))
+
+  const outcomes: GitHubRepositoryOutcome[] = []
+  const failures: { fullName: string, failure: RequestFailure }[] = []
+  let completed = 0
+
+  await Promise.all(targets.map(async (target) => {
+    const existing = cacheMap.get(target.fullName.toLowerCase())
+    const cache = existing ? present(existing) : absent<GitHubRepositoryCache>()
+    const outcome = await fetchGitHubRepository(dependencies, target, cache)
+    if (outcome.ok) {
+      outcomes.push(outcome.value)
+    }
+    else {
+      failures.push({ fullName: target.fullName, failure: outcome.error })
+    }
+    completed += 1
+    if (completed % 100 === 0)
+      console.log(`[github] ${completed}/${targets.length} repository checks completed`)
+  }))
+
+  if (failures.length > 0) {
+    failures.sort((left, right) => left.fullName.localeCompare(right.fullName))
+    const first = failures.at(0)
+    if (typeof first !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: 'github failure list is empty despite reported failures',
+      })
+    }
+    console.error(`[github] ${failures.length} repository check(s) failed; first failure for "${first.fullName}"`)
+    return failure(first.failure)
+  }
+
+  const records = outcomes.map(outcome => outcome.record)
+  records.sort((left, right) => left.data.fullName.localeCompare(right.data.fullName))
+  console.log(`[github] all ${records.length} repository checks completed`)
+  return ok(records)
+}
+
+export function mapGitHubRecordsToPackages(
+  packageTargets: readonly PackageGitHubTarget[],
+  repositoryRecords: readonly GitHubRepositoryRecord[],
+): Result<readonly PackageGitHubData[], RequestFailure> {
+  const recordMap = new Map(repositoryRecords.map(record => [record.data.fullName.toLowerCase(), record]))
+  const mapped: PackageGitHubData[] = []
+  for (const target of packageTargets) {
+    if (target.kind === 'absent') {
+      mapped.push({ kind: 'absent', packageName: target.packageName })
+      continue
+    }
+    const record = recordMap.get(target.target.fullName.toLowerCase())
+    if (typeof record !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: `github record for "${target.target.fullName}" is missing from successful responses`,
+      })
+    }
+    mapped.push({
+      kind: 'repository',
+      packageName: target.packageName,
+      repository: record,
+    })
+  }
+  return ok(mapped)
+}
+
+export function createGitHubClient(dependencies: GitHubClientDependencies) {
+  return {
+    fetchGitHubRepository: (target: GitHubRepositoryTarget, cache: Presence<GitHubRepositoryCache>) =>
+      fetchGitHubRepository(dependencies, target, cache),
+    fetchAllGitHubRepositories: (targets: readonly GitHubRepositoryTarget[]) =>
+      fetchAllGitHubRepositories(dependencies, targets),
+    mapGitHubRecordsToPackages,
+  }
+}

--- a/packages/generate/src/generate-plugin/github-client.ts
+++ b/packages/generate/src/generate-plugin/github-client.ts
@@ -2,10 +2,11 @@
 // 相同仓库只请求一次；200 更新缓存并要求 ETag；304 必须与缓存 ETag/hash 一致；
 // 存在 GitHub 链接但 API 未成功时整个快照失败，绝不把 Stars 写为 0。
 
-import type { GitHubRepositoryCache, GitHubRepositoryOutcome, GitHubRepositoryRecord, GitHubRepositoryTarget, HttpHeader, HttpRequest, PackageGitHubData, PackageGitHubTarget, Presence, RequestFailure, Result, StateStore } from './contracts'
+import type { CacheStore, GitHubRepositoryCache, GitHubRepositoryOutcome, GitHubRepositoryRecord, GitHubRepositoryTarget, HttpHeader, HttpRequest, PackageGitHubData, PackageGitHubTarget, Presence, RequestFailure, Result } from './contracts'
 import type { HostScheduler } from './host-scheduler'
 import {
   absent,
+
   failure,
 
   ok,
@@ -21,8 +22,7 @@ const GITHUB_ENDPOINT = 'https://api.github.com'
 
 export interface GitHubClientDependencies {
   scheduler: HostScheduler
-  store: StateStore
-  runId: string
+  cacheStore: CacheStore
   token: string
 }
 
@@ -49,60 +49,36 @@ export function createGitHubRequest(
   }
 }
 
-function githubTaskKey(target: GitHubRepositoryTarget): string {
-  return target.fullName.toLowerCase()
-}
-
 export async function fetchGitHubRepository(
   dependencies: GitHubClientDependencies,
   target: GitHubRepositoryTarget,
   cache: Presence<GitHubRepositoryCache>,
 ): Promise<Result<GitHubRepositoryOutcome, RequestFailure>> {
-  const taskKey = githubTaskKey(target)
   const request = createGitHubRequest(target, cache, dependencies.token, dependencies.scheduler.policy.requestTimeoutMs)
   const scheduled = await executeScheduled(request, dependencies.scheduler)
-
-  if (!scheduled.ok) {
-    const recorded = await dependencies.store.recordTaskFailure(
-      dependencies.runId,
-      'github',
-      taskKey,
-      scheduled.error.attempts,
-      scheduled.error.failure,
-    )
-    if (!recorded.ok) {
-      console.error(`failed to record github task failure for "${taskKey}"`, scheduled.error.failure)
-      return failure(recorded.error)
-    }
+  if (!scheduled.ok)
     return failure(scheduled.error.failure)
-  }
 
   const { response, attempts } = scheduled.value
 
   if (response.kind === 'not-modified') {
     if (cache.state !== 'present') {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `github returned 304 for "${target.fullName}" without a local cache entity`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
     if (cache.value.fullName.toLowerCase() !== target.fullName.toLowerCase()) {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `github cache entity "${cache.value.fullName}" does not match the requested repository "${target.fullName}"`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
     if (!isValidResponseHash(cache.value.responseHash)) {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `github cache hash for "${target.fullName}" failed validation`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
 
     const record: GitHubRepositoryRecord = {
@@ -110,26 +86,17 @@ export async function fetchGitHubRepository(
       etag: cache.value.etag,
       validation: 'response-304',
     }
-    const saved = await dependencies.store.saveGitHubRepositories(dependencies.runId, [
-      { record, nextCache: absent<GitHubRepositoryCache>(), attempts },
-    ])
-    if (!saved.ok)
-      return failure(saved.error)
     return ok({ record, nextCache: absent<GitHubRepositoryCache>(), attempts })
   }
 
   const decoded = decodeGitHubRepository(response.body, target.fullName)
-  if (!decoded.ok) {
-    await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, decoded.error)
+  if (!decoded.ok)
     return decoded
-  }
   if (response.metadata.etag.state !== 'present') {
-    const failureInfo: RequestFailure = {
+    return failure({
       kind: 'invariant',
       message: `github response for "${target.fullName}" does not carry an ETag validator`,
-    }
-    await dependencies.store.recordTaskFailure(dependencies.runId, 'github', taskKey, attempts, failureInfo)
-    return failure(failureInfo)
+    })
   }
 
   const etag = response.metadata.etag.value
@@ -139,16 +106,14 @@ export async function fetchGitHubRepository(
     responseHash: sha256Hex(response.body),
     data: decoded.value,
   }
+  const saved = dependencies.cacheStore.saveGitHubCache(nextCache)
+  if (!saved.ok)
+    return failure(saved.error)
   const record: GitHubRepositoryRecord = {
     data: decoded.value,
     etag,
     validation: 'response-200',
   }
-  const saved = await dependencies.store.saveGitHubRepositories(dependencies.runId, [
-    { record, nextCache: present(nextCache), attempts },
-  ])
-  if (!saved.ok)
-    return failure(saved.error)
   return ok({ record, nextCache: present(nextCache), attempts })
 }
 
@@ -156,7 +121,7 @@ export async function fetchAllGitHubRepositories(
   dependencies: GitHubClientDependencies,
   targets: readonly GitHubRepositoryTarget[],
 ): Promise<Result<readonly GitHubRepositoryRecord[], RequestFailure>> {
-  const caches = await dependencies.store.readGitHubCaches()
+  const caches = dependencies.cacheStore.readGitHubCaches()
   if (!caches.ok)
     return caches
   const cacheMap = new Map(caches.value.map(entry => [entry.fullName.toLowerCase(), entry]))

--- a/packages/generate/src/generate-plugin/host-scheduler.ts
+++ b/packages/generate/src/generate-plugin/host-scheduler.ts
@@ -1,0 +1,130 @@
+// Host 调度：每个 API Host 独立的并发、速率、重试、暂停与熔断。
+// 所有重试都重新提交给相同 Host Scheduler，确保重试同样受限速控制。
+
+import type { HostPolicy, HttpRequest, HttpSuccess, RequestFailure, Result } from './contracts'
+import PQueue from 'p-queue'
+import {
+  failure,
+
+  ok,
+
+} from './contracts'
+import { sendOnce } from './http-client'
+import { sleep } from './utils'
+
+export interface ScheduledSuccess {
+  response: HttpSuccess
+  attempts: number
+}
+
+export interface ScheduledFailure {
+  failure: RequestFailure
+  attempts: number
+}
+
+export interface HostScheduler {
+  readonly policy: HostPolicy
+  execute: (request: HttpRequest) => Promise<Result<HttpSuccess, RequestFailure>>
+}
+
+export function createHostScheduler(policy: HostPolicy): HostScheduler {
+  const queue = new PQueue({
+    concurrency: policy.concurrency,
+    interval: policy.intervalMs,
+    intervalCap: policy.intervalCap,
+  })
+  let consecutiveFailures = 0
+  let breakerOpenUntil = 0
+  let rateLimitRemaining = Number.POSITIVE_INFINITY
+  let rateLimitResetAtMs = 0
+
+  return {
+    policy,
+    async execute(request: HttpRequest): Promise<Result<HttpSuccess, RequestFailure>> {
+      const beforeBreaker = Date.now()
+      if (beforeBreaker < breakerOpenUntil)
+        await sleep(breakerOpenUntil - beforeBreaker)
+      if (rateLimitRemaining === 0 && Date.now() < rateLimitResetAtMs + 5000)
+        await sleep(rateLimitResetAtMs + 5000 - Date.now())
+
+      const queued = await queue.add(() => sendOnce(request))
+      if (!queued) {
+        return failure({
+          kind: 'invariant',
+          message: `host scheduler "${request.host}" returned no queued result`,
+        })
+      }
+
+      if (queued.ok) {
+        consecutiveFailures = 0
+        if (queued.value.metadata.rateLimitRemaining.state === 'present') {
+          rateLimitRemaining = queued.value.metadata.rateLimitRemaining.value
+          const resetAt = queued.value.metadata.rateLimitResetAt
+          if (resetAt.state === 'present')
+            rateLimitResetAtMs = resetAt.value
+        }
+        return queued
+      }
+
+      consecutiveFailures += 1
+      if (consecutiveFailures >= policy.circuitBreakerThreshold) {
+        breakerOpenUntil = Date.now() + policy.circuitBreakerPauseMs
+        consecutiveFailures = 0
+      }
+      return queued
+    },
+  }
+}
+
+const RETRY_BACKOFF_MS: readonly number[] = [1000, 2000, 4000, 8000, 16000, 30000, 60000]
+
+function jitteredBackoff(attempt: number): number {
+  const index = Math.min(attempt - 1, RETRY_BACKOFF_MS.length - 1)
+  const base = RETRY_BACKOFF_MS[index] ?? RETRY_BACKOFF_MS[RETRY_BACKOFF_MS.length - 1] ?? 60000
+  return Math.round(base * (0.5 + Math.random()))
+}
+
+export function calculateRetryDelay(
+  failureInfo: RequestFailure,
+  attempt: number,
+  nowEpochMs: number,
+): Result<number, RequestFailure> {
+  if (failureInfo.kind === 'network' || failureInfo.kind === 'timeout')
+    return ok(jitteredBackoff(attempt))
+  if (failureInfo.kind !== 'http')
+    return failure(failureInfo)
+
+  const retryableStatus = failureInfo.status === 408
+    || failureInfo.status === 425
+    || failureInfo.status === 429
+    || (failureInfo.status >= 500 && failureInfo.status <= 599)
+  const rateLimited = failureInfo.status === 403
+    && failureInfo.rateLimitRemaining.state === 'present'
+    && failureInfo.rateLimitRemaining.value === 0
+  if (!retryableStatus && !rateLimited)
+    return failure(failureInfo)
+
+  if (failureInfo.retryAfterMs.state === 'present')
+    return ok(failureInfo.retryAfterMs.value)
+  if (failureInfo.rateLimitResetAt.state === 'present' && (rateLimited || failureInfo.status === 429))
+    return ok(Math.max(0, failureInfo.rateLimitResetAt.value + 5000 - nowEpochMs))
+  return ok(jitteredBackoff(attempt))
+}
+
+export async function executeScheduled(
+  request: HttpRequest,
+  scheduler: HostScheduler,
+): Promise<Result<ScheduledSuccess, ScheduledFailure>> {
+  let lastFailure: RequestFailure = { kind: 'invariant', message: 'retry loop did not execute' }
+  for (let attempt = 1; attempt <= scheduler.policy.maxAttemptsPerRun; attempt++) {
+    const result = await scheduler.execute(request)
+    if (result.ok)
+      return ok({ response: result.value, attempts: attempt })
+    lastFailure = result.error
+    const delay = calculateRetryDelay(result.error, attempt, Date.now())
+    if (!delay.ok)
+      return failure({ failure: result.error, attempts: attempt })
+    await sleep(delay.value)
+  }
+  return failure({ failure: lastFailure, attempts: scheduler.policy.maxAttemptsPerRun })
+}

--- a/packages/generate/src/generate-plugin/http-client.ts
+++ b/packages/generate/src/generate-plugin/http-client.ts
@@ -1,0 +1,108 @@
+// HTTP 边界：只发送一次请求并返回结构化结果，不负责重试。
+// 所有响应头统一转换为显式 Presence 判别联合。
+
+import type { HttpHeader, HttpRequest, HttpSuccess, Presence, RequestFailure, ResponseMetadata, Result } from './contracts'
+import {
+  absent,
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+
+function stringHeader(headers: Headers, name: string): Presence<string> {
+  const raw = headers.get(name)
+  if (typeof raw !== 'string' || raw.length === 0)
+    return absent()
+  return present(raw)
+}
+
+function secondsHeader(headers: Headers, name: string): Presence<number> {
+  const raw = headers.get(name)
+  if (typeof raw !== 'string')
+    return absent()
+  const seconds = Number(raw)
+  if (Number.isSafeInteger(seconds) && seconds >= 0)
+    return present(seconds * 1000)
+  const httpDate = Date.parse(raw)
+  if (Number.isFinite(httpDate))
+    return present(Math.max(0, httpDate - Date.now()))
+  return absent()
+}
+
+function numberHeader(headers: Headers, name: string): Presence<number> {
+  const raw = headers.get(name)
+  if (typeof raw !== 'string')
+    return absent()
+  const parsed = Number(raw)
+  if (Number.isSafeInteger(parsed) && parsed >= 0)
+    return present(parsed)
+  return absent()
+}
+
+function readResponseMetadata(response: Response): ResponseMetadata {
+  const resetAtSeconds = numberHeader(response.headers, 'x-ratelimit-reset')
+  return {
+    status: response.status,
+    etag: stringHeader(response.headers, 'etag'),
+    lastModified: stringHeader(response.headers, 'last-modified'),
+    retryAfterMs: secondsHeader(response.headers, 'retry-after'),
+    rateLimitLimit: numberHeader(response.headers, 'x-ratelimit-limit'),
+    rateLimitRemaining: numberHeader(response.headers, 'x-ratelimit-remaining'),
+    rateLimitUsed: numberHeader(response.headers, 'x-ratelimit-used'),
+    rateLimitResetAt: resetAtSeconds.state === 'present'
+      ? present(resetAtSeconds.value * 1000)
+      : absent(),
+  }
+}
+
+function httpFailure(status: number, body: string, metadata: ResponseMetadata): RequestFailure {
+  return {
+    kind: 'http',
+    status,
+    body: body.slice(0, 2000),
+    retryAfterMs: metadata.retryAfterMs,
+    rateLimitRemaining: metadata.rateLimitRemaining,
+    rateLimitResetAt: metadata.rateLimitResetAt,
+  }
+}
+
+function transportFailure(error: Error, timeoutMs: number): RequestFailure {
+  if (error.name === 'TimeoutError' || error.name === 'AbortError')
+    return { kind: 'timeout', timeoutMs }
+  return { kind: 'network', message: error.message }
+}
+
+function buildHeaderInit(headers: readonly HttpHeader[]): Record<string, string> {
+  const headerInit: Record<string, string> = {}
+  for (const header of headers)
+    headerInit[header.name] = header.value
+  return headerInit
+}
+
+export async function sendOnce(request: HttpRequest): Promise<Result<HttpSuccess, RequestFailure>> {
+  try {
+    const response = await fetch(request.url, {
+      method: request.method,
+      headers: buildHeaderInit(request.headers),
+      signal: AbortSignal.timeout(request.timeoutMs),
+      redirect: 'follow',
+    })
+    const metadata = readResponseMetadata(response)
+    if (response.status === 304)
+      return ok({ kind: 'not-modified', metadata })
+    if (response.status >= 200 && response.status < 300) {
+      const body = await response.text()
+      return ok({ kind: 'body', body, metadata })
+    }
+    const body = await response.text()
+    return failure(httpFailure(response.status, body, metadata))
+  }
+  catch (error) {
+    if (error instanceof Error)
+      return failure(transportFailure(error, request.timeoutMs))
+    return failure({ kind: 'network', message: String(error) })
+  }
+}

--- a/packages/generate/src/generate-plugin/npm-downloads-client.ts
+++ b/packages/generate/src/generate-plugin/npm-downloads-client.ts
@@ -2,7 +2,7 @@
 // 先用 anchor 包锚定统计周期，非 scoped 包走 bulk（<=100 且 URL <=7000 字符），
 // scoped 包逐个请求；decoder 校验请求与响应集合完全一致。
 
-import type { CompletedDownloadBatch, DownloadBatch, DownloadPeriod, DownloadPoint, HttpRequest, PackageDownloads, RequestFailure, Result, StateStore } from './contracts'
+import type { CompletedDownloadBatch, DownloadBatch, DownloadPeriod, DownloadPoint, HttpRequest, PackageDownloads, RequestFailure, Result } from './contracts'
 import type { HostScheduler } from './host-scheduler'
 import {
 
@@ -25,8 +25,6 @@ const ANCHOR_PACKAGE_NAME = 'npm'
 
 export interface DownloadsClientDependencies {
   scheduler: HostScheduler
-  store: StateStore
-  runId: string
 }
 
 function downloadsRequest(dependencies: DownloadsClientDependencies, url: string): HttpRequest {
@@ -42,38 +40,16 @@ function downloadsRequest(dependencies: DownloadsClientDependencies, url: string
 async function requestDownloadsBody(
   dependencies: DownloadsClientDependencies,
   request: HttpRequest,
-  taskKey: string,
 ): Promise<Result<string, RequestFailure>> {
   const scheduled = await executeScheduled(request, dependencies.scheduler)
-  if (!scheduled.ok) {
-    const recorded = await dependencies.store.recordTaskFailure(
-      dependencies.runId,
-      'npm-downloads',
-      taskKey,
-      scheduled.error.attempts,
-      scheduled.error.failure,
-    )
-    if (!recorded.ok) {
-      console.error(`failed to record downloads task failure for "${taskKey}"`, scheduled.error.failure)
-      return failure(recorded.error)
-    }
+  if (!scheduled.ok)
     return failure(scheduled.error.failure)
-  }
   if (scheduled.value.response.kind !== 'body') {
     return failure({
       kind: 'invariant',
       message: `npm downloads endpoint "${request.url}" returned an unexpected not-modified response`,
     })
   }
-  const recorded = await dependencies.store.recordTaskSuccess(
-    dependencies.runId,
-    'npm-downloads',
-    taskKey,
-    scheduled.value.attempts,
-    scheduled.value.response.metadata.status,
-  )
-  if (!recorded.ok)
-    return failure(recorded.error)
   return ok(scheduled.value.response.body)
 }
 
@@ -94,7 +70,6 @@ export async function resolveDownloadPeriods(
   const dailyBody = await requestDownloadsBody(
     dependencies,
     downloadsRequest(dependencies, buildPointUrl({ kind: 'daily', start: '', end: '', apiPeriod: 'last-day' }, ANCHOR_PACKAGE_NAME)),
-    'anchor:last-day',
   )
   if (!dailyBody.ok)
     return dailyBody
@@ -105,7 +80,6 @@ export async function resolveDownloadPeriods(
   const monthlyBody = await requestDownloadsBody(
     dependencies,
     downloadsRequest(dependencies, buildPointUrl({ kind: 'monthly', start: '', end: '', apiPeriod: 'last-month' }, ANCHOR_PACKAGE_NAME)),
-    'anchor:last-month',
   )
   if (!monthlyBody.ok)
     return monthlyBody
@@ -184,22 +158,11 @@ export function createDownloadBatches(
   return ok(batches)
 }
 
-function downloadBatchTaskKey(batch: DownloadBatch): string {
-  if (batch.requestedPackageNames.length === 1)
-    return `${batch.kind}:single:${batch.requestedPackageNames[0]}`
-  return `${batch.kind}:bulk:${batch.requestedPackageNames.length}:${batch.requestedPackageNames[0]}..${batch.requestedPackageNames.at(-1)}`
-}
-
 export async function fetchDownloadBatch(
   dependencies: DownloadsClientDependencies,
   batch: DownloadBatch,
 ): Promise<Result<CompletedDownloadBatch, RequestFailure>> {
-  const taskKey = downloadBatchTaskKey(batch)
-  const body = await requestDownloadsBody(
-    dependencies,
-    downloadsRequest(dependencies, batch.requestUrl),
-    taskKey,
-  )
+  const body = await requestDownloadsBody(dependencies, downloadsRequest(dependencies, batch.requestUrl))
   if (!body.ok)
     return body
 
@@ -228,20 +191,6 @@ export async function fetchDownloadBatch(
 
 function matchesPeriod(point: DownloadPoint, period: DownloadPeriod): boolean {
   return point.start === period.start && point.end === period.end
-}
-
-function isBatchComplete(batch: DownloadBatch, collected: Map<string, Map<string, DownloadPoint>>): boolean {
-  for (const packageName of batch.requestedPackageNames) {
-    const perKind = collected.get(packageName)
-    if (typeof perKind !== 'object')
-      return false
-    const point = perKind.get(batch.kind)
-    if (typeof point !== 'object')
-      return false
-    if (!matchesPeriod(point, batch.period))
-      return false
-  }
-  return true
 }
 
 export async function fetchAllDownloads(
@@ -289,76 +238,31 @@ export async function fetchAllDownloads(
   const allBatches = [...dailyBatches.value, ...monthlyBatches.value, ...scopedBatches]
   console.log(`[npm-downloads] ${allBatches.length} batch request(s) planned: ${dailyBatches.value.length} daily bulk, ${monthlyBatches.value.length} monthly bulk, ${scopedNames.length * 2} scoped single`)
 
-  // 断点续传：读取已完成的 working points；周期不匹配的丢弃（本轮重新请求）。
-  const working = await dependencies.store.readWorkingDownloadPoints(dependencies.runId)
-  if (!working.ok)
-    return working
   const collected = new Map<string, Map<string, DownloadPoint>>()
-  const savedPairs = new Set<string>()
-  for (const point of working.value) {
-    const period = point.start === dailyPeriod.start && point.end === dailyPeriod.end ? dailyPeriod : monthlyPeriod
-    if (!matchesPeriod(point, period))
-      continue
-    let perKind = collected.get(point.packageName)
-    if (typeof perKind !== 'object') {
-      perKind = new Map()
-      collected.set(point.packageName, perKind)
-    }
-    perKind.set(period.kind, point)
-    savedPairs.add(`${period.kind}:${point.packageName}`)
-  }
-
-  const pendingBatches = allBatches.filter(batch => !isBatchComplete(batch, collected))
-  console.log(`[npm-downloads] ${pendingBatches.length} batch request(s) pending after resume seeding`)
-
-  const failures: { taskKey: string, failure: RequestFailure }[] = []
+  const failures: { requestUrl: string, failure: RequestFailure }[] = []
   let completedBatches = 0
 
-  const savePair = async (point: DownloadPoint, period: DownloadPeriod): Promise<Result<boolean, RequestFailure>> => {
-    const pairKey = `${period.kind}:${point.packageName}`
-    if (savedPairs.has(pairKey))
-      return ok(true)
-    let perKind = collected.get(point.packageName)
-    if (typeof perKind !== 'object') {
-      perKind = new Map()
-      collected.set(point.packageName, perKind)
-    }
-    perKind.set(period.kind, point)
-    const daily = perKind.get('daily')
-    const monthly = perKind.get('monthly')
-    if (typeof daily !== 'object' || typeof monthly !== 'object')
-      return ok(true)
-    savedPairs.add(pairKey)
-    const saved = await dependencies.store.saveDownloads(dependencies.runId, [{
-      packageName: point.packageName,
-      daily,
-      monthly,
-    }])
-    if (!saved.ok)
-      return failure(saved.error)
-    return ok(true)
-  }
-
-  await Promise.all(pendingBatches.map(async (batch) => {
+  await Promise.all(allBatches.map(async (batch) => {
     const result = await fetchDownloadBatch(dependencies, batch)
     if (!result.ok) {
-      failures.push({ taskKey: downloadBatchTaskKey(batch), failure: result.error })
+      failures.push({ requestUrl: batch.requestUrl, failure: result.error })
       return
     }
     for (const point of result.value.points) {
-      const saved = await savePair(point, batch.period)
-      if (!saved.ok) {
-        failures.push({ taskKey: downloadBatchTaskKey(batch), failure: saved.error })
-        return
+      let perKind = collected.get(point.packageName)
+      if (typeof perKind !== 'object') {
+        perKind = new Map()
+        collected.set(point.packageName, perKind)
       }
+      perKind.set(batch.kind, point)
     }
     completedBatches += 1
     if (completedBatches % 25 === 0)
-      console.log(`[npm-downloads] ${completedBatches}/${pendingBatches.length} batches completed`)
+      console.log(`[npm-downloads] ${completedBatches}/${allBatches.length} batches completed`)
   }))
 
   if (failures.length > 0) {
-    failures.sort((left, right) => left.taskKey.localeCompare(right.taskKey))
+    failures.sort((left, right) => left.requestUrl.localeCompare(right.requestUrl))
     const first = failures.at(0)
     if (typeof first !== 'object') {
       return failure({
@@ -366,7 +270,7 @@ export async function fetchAllDownloads(
         message: 'downloads failure list is empty despite reported failures',
       })
     }
-    console.error(`[npm-downloads] ${failures.length} batch request(s) failed; first failure at "${first.taskKey}"`)
+    console.error(`[npm-downloads] ${failures.length} batch request(s) failed; first failure at "${first.requestUrl}"`)
     return failure(first.failure)
   }
 

--- a/packages/generate/src/generate-plugin/npm-downloads-client.ts
+++ b/packages/generate/src/generate-plugin/npm-downloads-client.ts
@@ -1,0 +1,408 @@
+// 阶段三：每日全量 Downloads。
+// 先用 anchor 包锚定统计周期，非 scoped 包走 bulk（<=100 且 URL <=7000 字符），
+// scoped 包逐个请求；decoder 校验请求与响应集合完全一致。
+
+import type { CompletedDownloadBatch, DownloadBatch, DownloadPeriod, DownloadPoint, HttpRequest, PackageDownloads, RequestFailure, Result, StateStore } from './contracts'
+import type { HostScheduler } from './host-scheduler'
+import {
+
+  failure,
+
+  ok,
+
+} from './contracts'
+import { executeScheduled } from './host-scheduler'
+import {
+  decodeAnchorDownloadPoint,
+  decodeDownloadBulkResponse,
+  decodeDownloadPoint,
+  DOWNLOAD_BATCH_MAX_SIZE,
+  DOWNLOAD_BATCH_MAX_URL_LENGTH,
+} from './schemas'
+
+const DOWNLOADS_ENDPOINT = 'https://api.npmjs.org/downloads'
+const ANCHOR_PACKAGE_NAME = 'npm'
+
+export interface DownloadsClientDependencies {
+  scheduler: HostScheduler
+  store: StateStore
+  runId: string
+}
+
+function downloadsRequest(dependencies: DownloadsClientDependencies, url: string): HttpRequest {
+  return {
+    host: 'npm-downloads',
+    method: 'GET',
+    url,
+    headers: [{ name: 'accept', value: 'application/json' }],
+    timeoutMs: dependencies.scheduler.policy.requestTimeoutMs,
+  }
+}
+
+async function requestDownloadsBody(
+  dependencies: DownloadsClientDependencies,
+  request: HttpRequest,
+  taskKey: string,
+): Promise<Result<string, RequestFailure>> {
+  const scheduled = await executeScheduled(request, dependencies.scheduler)
+  if (!scheduled.ok) {
+    const recorded = await dependencies.store.recordTaskFailure(
+      dependencies.runId,
+      'npm-downloads',
+      taskKey,
+      scheduled.error.attempts,
+      scheduled.error.failure,
+    )
+    if (!recorded.ok) {
+      console.error(`failed to record downloads task failure for "${taskKey}"`, scheduled.error.failure)
+      return failure(recorded.error)
+    }
+    return failure(scheduled.error.failure)
+  }
+  if (scheduled.value.response.kind !== 'body') {
+    return failure({
+      kind: 'invariant',
+      message: `npm downloads endpoint "${request.url}" returned an unexpected not-modified response`,
+    })
+  }
+  const recorded = await dependencies.store.recordTaskSuccess(
+    dependencies.runId,
+    'npm-downloads',
+    taskKey,
+    scheduled.value.attempts,
+    scheduled.value.response.metadata.status,
+  )
+  if (!recorded.ok)
+    return failure(recorded.error)
+  return ok(scheduled.value.response.body)
+}
+
+function buildPointUrl(period: DownloadPeriod, packageName: string): string {
+  return `${DOWNLOADS_ENDPOINT}/point/${period.apiPeriod}/${encodeURIComponent(packageName)}`
+}
+
+function buildBulkUrl(period: DownloadPeriod, packageNames: readonly string[]): string {
+  const encoded = packageNames.map(name => encodeURIComponent(name)).join(',')
+  return `${DOWNLOADS_ENDPOINT}/point/${period.apiPeriod}/${encoded}`
+}
+
+// 先锚定统计周期：禁止在本地猜测 npm 的最新完整统计日。
+// 本轮后续所有包都使用显式日期，避免任务跨 UTC 日期边界后出现周期不一致。
+export async function resolveDownloadPeriods(
+  dependencies: DownloadsClientDependencies,
+): Promise<Result<readonly [DownloadPeriod, DownloadPeriod], RequestFailure>> {
+  const dailyBody = await requestDownloadsBody(
+    dependencies,
+    downloadsRequest(dependencies, buildPointUrl({ kind: 'daily', start: '', end: '', apiPeriod: 'last-day' }, ANCHOR_PACKAGE_NAME)),
+    'anchor:last-day',
+  )
+  if (!dailyBody.ok)
+    return dailyBody
+  const dailyPoint = decodeAnchorDownloadPoint(dailyBody.value, ANCHOR_PACKAGE_NAME)
+  if (!dailyPoint.ok)
+    return dailyPoint
+
+  const monthlyBody = await requestDownloadsBody(
+    dependencies,
+    downloadsRequest(dependencies, buildPointUrl({ kind: 'monthly', start: '', end: '', apiPeriod: 'last-month' }, ANCHOR_PACKAGE_NAME)),
+    'anchor:last-month',
+  )
+  if (!monthlyBody.ok)
+    return monthlyBody
+  const monthlyPoint = decodeAnchorDownloadPoint(monthlyBody.value, ANCHOR_PACKAGE_NAME)
+  if (!monthlyPoint.ok)
+    return monthlyPoint
+
+  const dailyPeriod: DownloadPeriod = {
+    kind: 'daily',
+    start: dailyPoint.value.start,
+    end: dailyPoint.value.end,
+    apiPeriod: dailyPoint.value.start,
+  }
+  const monthlyPeriod: DownloadPeriod = {
+    kind: 'monthly',
+    start: monthlyPoint.value.start,
+    end: monthlyPoint.value.end,
+    apiPeriod: `${monthlyPoint.value.start}:${monthlyPoint.value.end}`,
+  }
+  console.log(`[npm-downloads] anchored daily=${dailyPeriod.start}..${dailyPeriod.end} monthly=${monthlyPeriod.start}..${monthlyPeriod.end}`)
+  return ok([dailyPeriod, monthlyPeriod])
+}
+
+// 构建非 scoped bulk：每批最多 100 个包、编码后完整 URL 最长 7000 字符。
+// 最后一批只有一个包时按单包响应处理（decoder 依据 requestedPackageNames 长度选择 schema）。
+export function createDownloadBatches(
+  packageNames: readonly string[],
+  period: DownloadPeriod,
+  maximumBatchSize: number,
+  maximumUrlLength: number,
+): Result<readonly DownloadBatch[], RequestFailure> {
+  const batches: DownloadBatch[] = []
+  let current: string[] = []
+  let currentUrl = ''
+
+  const flush = () => {
+    if (current.length === 0)
+      return
+    batches.push({
+      kind: period.kind,
+      period,
+      requestedPackageNames: [...current],
+      requestUrl: currentUrl,
+    })
+    current = []
+    currentUrl = ''
+  }
+
+  for (const packageName of packageNames) {
+    if (packageName.includes('/')) {
+      return failure({
+        kind: 'invariant',
+        message: `scoped package "${packageName}" cannot join a downloads bulk request`,
+      })
+    }
+    const candidateUrl = current.length === 0
+      ? buildBulkUrl(period, [packageName])
+      : `${currentUrl},${encodeURIComponent(packageName)}`
+    if (current.length > 0 && (current.length >= maximumBatchSize || candidateUrl.length > maximumUrlLength)) {
+      flush()
+      currentUrl = buildBulkUrl(period, [packageName])
+    }
+    else {
+      currentUrl = candidateUrl
+    }
+    current.push(packageName)
+    if (currentUrl.length > maximumUrlLength) {
+      return failure({
+        kind: 'invariant',
+        message: `downloads bulk url exceeds ${maximumUrlLength} characters at package "${packageName}"`,
+      })
+    }
+  }
+  flush()
+
+  return ok(batches)
+}
+
+function downloadBatchTaskKey(batch: DownloadBatch): string {
+  if (batch.requestedPackageNames.length === 1)
+    return `${batch.kind}:single:${batch.requestedPackageNames[0]}`
+  return `${batch.kind}:bulk:${batch.requestedPackageNames.length}:${batch.requestedPackageNames[0]}..${batch.requestedPackageNames.at(-1)}`
+}
+
+export async function fetchDownloadBatch(
+  dependencies: DownloadsClientDependencies,
+  batch: DownloadBatch,
+): Promise<Result<CompletedDownloadBatch, RequestFailure>> {
+  const taskKey = downloadBatchTaskKey(batch)
+  const body = await requestDownloadsBody(
+    dependencies,
+    downloadsRequest(dependencies, batch.requestUrl),
+    taskKey,
+  )
+  if (!body.ok)
+    return body
+
+  let decoded: Result<readonly DownloadPoint[], RequestFailure>
+  if (batch.requestedPackageNames.length === 1) {
+    const only = batch.requestedPackageNames[0]
+    if (typeof only !== 'string') {
+      return failure({
+        kind: 'invariant',
+        message: 'download batch declares one package but carries no package name',
+      })
+    }
+    const point = decodeDownloadPoint(body.value, only, batch.period)
+    if (!point.ok)
+      return point
+    decoded = ok([point.value])
+  }
+  else {
+    decoded = decodeDownloadBulkResponse(body.value, batch.requestedPackageNames, batch.period)
+  }
+  if (!decoded.ok)
+    return decoded
+
+  return ok({ batch, points: decoded.value })
+}
+
+function matchesPeriod(point: DownloadPoint, period: DownloadPeriod): boolean {
+  return point.start === period.start && point.end === period.end
+}
+
+function isBatchComplete(batch: DownloadBatch, collected: Map<string, Map<string, DownloadPoint>>): boolean {
+  for (const packageName of batch.requestedPackageNames) {
+    const perKind = collected.get(packageName)
+    if (typeof perKind !== 'object')
+      return false
+    const point = perKind.get(batch.kind)
+    if (typeof point !== 'object')
+      return false
+    if (!matchesPeriod(point, batch.period))
+      return false
+  }
+  return true
+}
+
+export async function fetchAllDownloads(
+  dependencies: DownloadsClientDependencies,
+  packageNames: readonly string[],
+  dailyPeriod: DownloadPeriod,
+  monthlyPeriod: DownloadPeriod,
+): Promise<Result<readonly PackageDownloads[], RequestFailure>> {
+  const uniqueNames = new Set(packageNames)
+  if (uniqueNames.size !== packageNames.length) {
+    return failure({
+      kind: 'invariant',
+      message: 'downloads package list contains duplicates',
+    })
+  }
+
+  const plainNames: string[] = []
+  const scopedNames: string[] = []
+  for (const packageName of packageNames) {
+    if (packageName.includes('/'))
+      scopedNames.push(packageName)
+    else
+      plainNames.push(packageName)
+  }
+
+  const dailyBatches = createDownloadBatches(plainNames, dailyPeriod, DOWNLOAD_BATCH_MAX_SIZE, DOWNLOAD_BATCH_MAX_URL_LENGTH)
+  if (!dailyBatches.ok)
+    return dailyBatches
+  const monthlyBatches = createDownloadBatches(plainNames, monthlyPeriod, DOWNLOAD_BATCH_MAX_SIZE, DOWNLOAD_BATCH_MAX_URL_LENGTH)
+  if (!monthlyBatches.ok)
+    return monthlyBatches
+
+  const scopedBatches: DownloadBatch[] = []
+  for (const period of [dailyPeriod, monthlyPeriod]) {
+    for (const packageName of scopedNames) {
+      scopedBatches.push({
+        kind: period.kind,
+        period,
+        requestedPackageNames: [packageName],
+        requestUrl: buildPointUrl(period, packageName),
+      })
+    }
+  }
+
+  const allBatches = [...dailyBatches.value, ...monthlyBatches.value, ...scopedBatches]
+  console.log(`[npm-downloads] ${allBatches.length} batch request(s) planned: ${dailyBatches.value.length} daily bulk, ${monthlyBatches.value.length} monthly bulk, ${scopedNames.length * 2} scoped single`)
+
+  // 断点续传：读取已完成的 working points；周期不匹配的丢弃（本轮重新请求）。
+  const working = await dependencies.store.readWorkingDownloadPoints(dependencies.runId)
+  if (!working.ok)
+    return working
+  const collected = new Map<string, Map<string, DownloadPoint>>()
+  const savedPairs = new Set<string>()
+  for (const point of working.value) {
+    const period = point.start === dailyPeriod.start && point.end === dailyPeriod.end ? dailyPeriod : monthlyPeriod
+    if (!matchesPeriod(point, period))
+      continue
+    let perKind = collected.get(point.packageName)
+    if (typeof perKind !== 'object') {
+      perKind = new Map()
+      collected.set(point.packageName, perKind)
+    }
+    perKind.set(period.kind, point)
+    savedPairs.add(`${period.kind}:${point.packageName}`)
+  }
+
+  const pendingBatches = allBatches.filter(batch => !isBatchComplete(batch, collected))
+  console.log(`[npm-downloads] ${pendingBatches.length} batch request(s) pending after resume seeding`)
+
+  const failures: { taskKey: string, failure: RequestFailure }[] = []
+  let completedBatches = 0
+
+  const savePair = async (point: DownloadPoint, period: DownloadPeriod): Promise<Result<boolean, RequestFailure>> => {
+    const pairKey = `${period.kind}:${point.packageName}`
+    if (savedPairs.has(pairKey))
+      return ok(true)
+    let perKind = collected.get(point.packageName)
+    if (typeof perKind !== 'object') {
+      perKind = new Map()
+      collected.set(point.packageName, perKind)
+    }
+    perKind.set(period.kind, point)
+    const daily = perKind.get('daily')
+    const monthly = perKind.get('monthly')
+    if (typeof daily !== 'object' || typeof monthly !== 'object')
+      return ok(true)
+    savedPairs.add(pairKey)
+    const saved = await dependencies.store.saveDownloads(dependencies.runId, [{
+      packageName: point.packageName,
+      daily,
+      monthly,
+    }])
+    if (!saved.ok)
+      return failure(saved.error)
+    return ok(true)
+  }
+
+  await Promise.all(pendingBatches.map(async (batch) => {
+    const result = await fetchDownloadBatch(dependencies, batch)
+    if (!result.ok) {
+      failures.push({ taskKey: downloadBatchTaskKey(batch), failure: result.error })
+      return
+    }
+    for (const point of result.value.points) {
+      const saved = await savePair(point, batch.period)
+      if (!saved.ok) {
+        failures.push({ taskKey: downloadBatchTaskKey(batch), failure: saved.error })
+        return
+      }
+    }
+    completedBatches += 1
+    if (completedBatches % 25 === 0)
+      console.log(`[npm-downloads] ${completedBatches}/${pendingBatches.length} batches completed`)
+  }))
+
+  if (failures.length > 0) {
+    failures.sort((left, right) => left.taskKey.localeCompare(right.taskKey))
+    const first = failures.at(0)
+    if (typeof first !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: 'downloads failure list is empty despite reported failures',
+      })
+    }
+    console.error(`[npm-downloads] ${failures.length} batch request(s) failed; first failure at "${first.taskKey}"`)
+    return failure(first.failure)
+  }
+
+  const records: PackageDownloads[] = []
+  for (const packageName of packageNames) {
+    const perKind = collected.get(packageName)
+    const daily = perKind?.get('daily')
+    const monthly = perKind?.get('monthly')
+    if (typeof daily !== 'object' || typeof monthly !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: `downloads for "${packageName}" are incomplete after all batches completed`,
+      })
+    }
+    if (!matchesPeriod(daily, dailyPeriod) || !matchesPeriod(monthly, monthlyPeriod)) {
+      return failure({
+        kind: 'invariant',
+        message: `downloads for "${packageName}" do not match the anchored periods`,
+      })
+    }
+    records.push({ packageName, daily, monthly })
+  }
+
+  console.log(`[npm-downloads] all ${records.length} package(s) have daily and monthly points`)
+  return ok(records)
+}
+
+export function createDownloadsClient(dependencies: DownloadsClientDependencies) {
+  return {
+    resolveDownloadPeriods: () => resolveDownloadPeriods(dependencies),
+    createDownloadBatches,
+    fetchDownloadBatch: (batch: DownloadBatch) => fetchDownloadBatch(dependencies, batch),
+    fetchAllDownloads: (
+      packageNames: readonly string[],
+      dailyPeriod: DownloadPeriod,
+      monthlyPeriod: DownloadPeriod,
+    ) => fetchAllDownloads(dependencies, packageNames, dailyPeriod, monthlyPeriod),
+  }
+}

--- a/packages/generate/src/generate-plugin/npm-registry-client.ts
+++ b/packages/generate/src/generate-plugin/npm-registry-client.ts
@@ -1,10 +1,11 @@
 // 阶段二：每日全量 Package Metadata 条件请求。
 // 有缓存实体与 Last-Modified 时发送 If-Modified-Since；304 必须与缓存严格匹配。
 
-import type { HttpHeader, HttpRequest, PackageMetadataCache, PackageMetadataOutcome, PackageMetadataRecord, PackageTarget, Presence, ReplicationSnapshot, RequestFailure, Result, StateStore } from './contracts'
+import type { CacheStore, HttpHeader, HttpRequest, PackageMetadataCache, PackageMetadataOutcome, PackageMetadataRecord, PackageTarget, Presence, ReplicationSnapshot, RequestFailure, Result } from './contracts'
 import type { HostScheduler } from './host-scheduler'
 import {
   absent,
+
   failure,
 
   ok,
@@ -20,8 +21,7 @@ const REGISTRY_ENDPOINT = 'https://registry.npmjs.org'
 
 export interface RegistryClientDependencies {
   scheduler: HostScheduler
-  store: StateStore
-  runId: string
+  cacheStore: CacheStore
 }
 
 export function createPackageMetadataRequest(
@@ -42,68 +42,42 @@ export function createPackageMetadataRequest(
   }
 }
 
-function metadataTaskKey(target: PackageTarget): string {
-  return target.packageName
-}
-
 export async function fetchPackageMetadata(
   dependencies: RegistryClientDependencies,
   target: PackageTarget,
   cache: Presence<PackageMetadataCache>,
 ): Promise<Result<PackageMetadataOutcome, RequestFailure>> {
-  const taskKey = metadataTaskKey(target)
   const request = createPackageMetadataRequest(target, cache, dependencies.scheduler.policy.requestTimeoutMs)
   const scheduled = await executeScheduled(request, dependencies.scheduler)
-
-  if (!scheduled.ok) {
-    const recorded = await dependencies.store.recordTaskFailure(
-      dependencies.runId,
-      'npm-registry',
-      taskKey,
-      scheduled.error.attempts,
-      scheduled.error.failure,
-    )
-    if (!recorded.ok) {
-      console.error(`failed to record metadata task failure for "${taskKey}"`, scheduled.error.failure)
-      return failure(recorded.error)
-    }
+  if (!scheduled.ok)
     return failure(scheduled.error.failure)
-  }
 
   const { response, attempts } = scheduled.value
 
   if (response.kind === 'not-modified') {
     if (cache.state !== 'present') {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `npm registry returned 304 for "${target.packageName}" without a local cache entity`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
     if (cache.value.packageName !== target.packageName) {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `npm registry cache entity "${cache.value.packageName}" does not match the requested package "${target.packageName}"`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
     if (!isValidResponseHash(cache.value.responseHash)) {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `npm registry cache hash for "${target.packageName}" failed validation`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
     if (cache.value.lastModified.state !== 'present') {
-      const failureInfo: RequestFailure = {
+      return failure({
         kind: 'invariant',
         message: `npm registry returned 304 for "${target.packageName}" but the cache entity has no Last-Modified validator`,
-      }
-      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
-      return failure(failureInfo)
+      })
     }
 
     const record: PackageMetadataRecord = {
@@ -112,19 +86,12 @@ export async function fetchPackageMetadata(
       metadata: cache.value.metadata,
       cacheValidator: cache.value.lastModified.value,
     }
-    const saved = await dependencies.store.savePackageMetadata(dependencies.runId, [
-      { record, cache: cache.value, attempts },
-    ])
-    if (!saved.ok)
-      return failure(saved.error)
     return ok({ record, cache: cache.value, attempts })
   }
 
   const decoded = decodePackageMetadata(response.body, target.packageName)
-  if (!decoded.ok) {
-    await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, decoded.error)
+  if (!decoded.ok)
     return decoded
-  }
 
   const cacheEntry: PackageMetadataCache = {
     packageName: target.packageName,
@@ -133,17 +100,15 @@ export async function fetchPackageMetadata(
     responseHash: sha256Hex(response.body),
     metadata: decoded.value,
   }
+  const saved = dependencies.cacheStore.saveMetadataCache(cacheEntry)
+  if (!saved.ok)
+    return failure(saved.error)
   const record: PackageMetadataRecord = {
     validation: 'response-200',
     target,
     metadata: decoded.value,
     cacheValidator: response.metadata.lastModified,
   }
-  const saved = await dependencies.store.savePackageMetadata(dependencies.runId, [
-    { record, cache: cacheEntry, attempts },
-  ])
-  if (!saved.ok)
-    return failure(saved.error)
   return ok({ record, cache: cacheEntry, attempts })
 }
 
@@ -151,7 +116,7 @@ export async function fetchAllPackageMetadata(
   dependencies: RegistryClientDependencies,
   snapshot: ReplicationSnapshot,
 ): Promise<Result<readonly PackageMetadataRecord[], RequestFailure>> {
-  const caches = await dependencies.store.readPackageMetadataCaches()
+  const caches = dependencies.cacheStore.readMetadataCaches()
   if (!caches.ok)
     return caches
   const cacheMap = new Map(caches.value.map(entry => [entry.packageName, entry]))

--- a/packages/generate/src/generate-plugin/npm-registry-client.ts
+++ b/packages/generate/src/generate-plugin/npm-registry-client.ts
@@ -1,0 +1,210 @@
+// 阶段二：每日全量 Package Metadata 条件请求。
+// 有缓存实体与 Last-Modified 时发送 If-Modified-Since；304 必须与缓存严格匹配。
+
+import type { HttpHeader, HttpRequest, PackageMetadataCache, PackageMetadataOutcome, PackageMetadataRecord, PackageTarget, Presence, ReplicationSnapshot, RequestFailure, Result, StateStore } from './contracts'
+import type { HostScheduler } from './host-scheduler'
+import {
+  absent,
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+import { executeScheduled } from './host-scheduler'
+import { decodePackageMetadata } from './schemas'
+import { isValidResponseHash, sha256Hex } from './utils'
+
+const REGISTRY_ENDPOINT = 'https://registry.npmjs.org'
+
+export interface RegistryClientDependencies {
+  scheduler: HostScheduler
+  store: StateStore
+  runId: string
+}
+
+export function createPackageMetadataRequest(
+  target: PackageTarget,
+  cache: Presence<PackageMetadataCache>,
+  timeoutMs: number,
+): HttpRequest {
+  const requestUrl = `${REGISTRY_ENDPOINT}/${encodeURIComponent(target.packageName)}/latest`
+  const headers: HttpHeader[] = [{ name: 'accept', value: 'application/json' }]
+  if (cache.state === 'present' && cache.value.lastModified.state === 'present')
+    headers.push({ name: 'If-Modified-Since', value: cache.value.lastModified.value })
+  return {
+    host: 'npm-registry',
+    method: 'GET',
+    url: requestUrl,
+    headers,
+    timeoutMs,
+  }
+}
+
+function metadataTaskKey(target: PackageTarget): string {
+  return target.packageName
+}
+
+export async function fetchPackageMetadata(
+  dependencies: RegistryClientDependencies,
+  target: PackageTarget,
+  cache: Presence<PackageMetadataCache>,
+): Promise<Result<PackageMetadataOutcome, RequestFailure>> {
+  const taskKey = metadataTaskKey(target)
+  const request = createPackageMetadataRequest(target, cache, dependencies.scheduler.policy.requestTimeoutMs)
+  const scheduled = await executeScheduled(request, dependencies.scheduler)
+
+  if (!scheduled.ok) {
+    const recorded = await dependencies.store.recordTaskFailure(
+      dependencies.runId,
+      'npm-registry',
+      taskKey,
+      scheduled.error.attempts,
+      scheduled.error.failure,
+    )
+    if (!recorded.ok) {
+      console.error(`failed to record metadata task failure for "${taskKey}"`, scheduled.error.failure)
+      return failure(recorded.error)
+    }
+    return failure(scheduled.error.failure)
+  }
+
+  const { response, attempts } = scheduled.value
+
+  if (response.kind === 'not-modified') {
+    if (cache.state !== 'present') {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `npm registry returned 304 for "${target.packageName}" without a local cache entity`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+    if (cache.value.packageName !== target.packageName) {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `npm registry cache entity "${cache.value.packageName}" does not match the requested package "${target.packageName}"`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+    if (!isValidResponseHash(cache.value.responseHash)) {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `npm registry cache hash for "${target.packageName}" failed validation`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+    if (cache.value.lastModified.state !== 'present') {
+      const failureInfo: RequestFailure = {
+        kind: 'invariant',
+        message: `npm registry returned 304 for "${target.packageName}" but the cache entity has no Last-Modified validator`,
+      }
+      await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, failureInfo)
+      return failure(failureInfo)
+    }
+
+    const record: PackageMetadataRecord = {
+      validation: 'response-304',
+      target,
+      metadata: cache.value.metadata,
+      cacheValidator: cache.value.lastModified.value,
+    }
+    const saved = await dependencies.store.savePackageMetadata(dependencies.runId, [
+      { record, cache: cache.value, attempts },
+    ])
+    if (!saved.ok)
+      return failure(saved.error)
+    return ok({ record, cache: cache.value, attempts })
+  }
+
+  const decoded = decodePackageMetadata(response.body, target.packageName)
+  if (!decoded.ok) {
+    await dependencies.store.recordTaskFailure(dependencies.runId, 'npm-registry', taskKey, attempts, decoded.error)
+    return decoded
+  }
+
+  const cacheEntry: PackageMetadataCache = {
+    packageName: target.packageName,
+    requestUrl: request.url,
+    lastModified: response.metadata.lastModified,
+    responseHash: sha256Hex(response.body),
+    metadata: decoded.value,
+  }
+  const record: PackageMetadataRecord = {
+    validation: 'response-200',
+    target,
+    metadata: decoded.value,
+    cacheValidator: response.metadata.lastModified,
+  }
+  const saved = await dependencies.store.savePackageMetadata(dependencies.runId, [
+    { record, cache: cacheEntry, attempts },
+  ])
+  if (!saved.ok)
+    return failure(saved.error)
+  return ok({ record, cache: cacheEntry, attempts })
+}
+
+export async function fetchAllPackageMetadata(
+  dependencies: RegistryClientDependencies,
+  snapshot: ReplicationSnapshot,
+): Promise<Result<readonly PackageMetadataRecord[], RequestFailure>> {
+  const caches = await dependencies.store.readPackageMetadataCaches()
+  if (!caches.ok)
+    return caches
+  const cacheMap = new Map(caches.value.map(entry => [entry.packageName, entry]))
+
+  const outcomes: PackageMetadataOutcome[] = []
+  const failures: { packageName: string, failure: RequestFailure }[] = []
+  let completed = 0
+
+  await Promise.all(snapshot.packages.map(async (target) => {
+    const existing = cacheMap.get(target.packageName)
+    const cache = existing ? present(existing) : absent<PackageMetadataCache>()
+    const outcome = await fetchPackageMetadata(dependencies, target, cache)
+    if (outcome.ok) {
+      outcomes.push(outcome.value)
+    }
+    else {
+      failures.push({ packageName: target.packageName, failure: outcome.error })
+    }
+    completed += 1
+    if (completed % 500 === 0)
+      console.log(`[npm-registry] ${completed}/${snapshot.packages.length} metadata checks completed`)
+  }))
+
+  if (failures.length > 0) {
+    failures.sort((left, right) => left.packageName.localeCompare(right.packageName))
+    const first = failures.at(0)
+    if (typeof first !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: 'metadata failure list is empty despite reported failures',
+      })
+    }
+    console.error(`[npm-registry] ${failures.length} metadata check(s) failed; first failure for "${first.packageName}"`)
+    return failure(first.failure)
+  }
+
+  if (outcomes.length !== snapshot.packages.length) {
+    return failure({
+      kind: 'invariant',
+      message: `metadata outcomes (${outcomes.length}) do not cover the replication snapshot (${snapshot.packages.length})`,
+    })
+  }
+
+  const records = outcomes.map(outcome => outcome.record)
+  records.sort((left, right) => left.target.packageName.localeCompare(right.target.packageName))
+  console.log(`[npm-registry] all ${records.length} metadata checks completed`)
+  return ok(records)
+}
+
+export function createRegistryClient(dependencies: RegistryClientDependencies) {
+  return {
+    fetchPackageMetadata: (target: PackageTarget, cache: Presence<PackageMetadataCache>) =>
+      fetchPackageMetadata(dependencies, target, cache),
+    fetchAllPackageMetadata: (snapshot: ReplicationSnapshot) => fetchAllPackageMetadata(dependencies, snapshot),
+  }
+}

--- a/packages/generate/src/generate-plugin/pipeline.ts
+++ b/packages/generate/src/generate-plugin/pipeline.ts
@@ -1,18 +1,11 @@
 // Pipeline：严格按五个阶段编排。任何必要数据失败或缺失时，本次快照不发布。
 
 import type { PipelineClock } from './clock'
-import type { ActiveSyncStage, CompletePluginSnapshot, HostPolicy, PluginDefinition, Presence, ReplicationBounds, RequestFailure, Result, StateStore, SyncRun } from './contracts'
+import type { CacheStore, CompletePluginSnapshot, HostPolicy, PluginDefinition, RequestFailure, Result } from './contracts'
 import type { HostScheduler } from './host-scheduler'
 import type { SnapshotPublisher } from './snapshot-publisher'
-import { randomUUID } from 'node:crypto'
 import { isValidIsoUtcTimestamp } from './clock'
-import {
-
-  failure,
-
-  ok,
-
-} from './contracts'
+import { failure, ok } from './contracts'
 import { createGitHubClient } from './github-client'
 import { createHostScheduler } from './host-scheduler'
 import { createDownloadsClient } from './npm-downloads-client'
@@ -22,7 +15,7 @@ import { collectPackageGitHubTargets, collectUniqueGitHubTargets } from './repos
 import { validateCompleteSnapshot } from './snapshot-validator'
 
 export interface PipelineDependencies {
-  store: StateStore
+  cacheStore: CacheStore
   clock: PipelineClock
   replicationPolicy: HostPolicy
   npmRegistryPolicy: HostPolicy
@@ -75,25 +68,6 @@ export const DEFAULT_HOST_POLICIES: Readonly<Record<'replication' | 'npm-registr
   },
 }
 
-function describeFailure(failureInfo: RequestFailure): string {
-  switch (failureInfo.kind) {
-    case 'network':
-      return `network: ${failureInfo.message}`
-    case 'timeout':
-      return `timeout after ${failureInfo.timeoutMs}ms`
-    case 'http':
-      return `http ${failureInfo.status}: ${failureInfo.body.slice(0, 200)}`
-    case 'schema':
-      return `schema: ${failureInfo.issues.join('; ')}`
-    case 'invariant':
-      return `invariant: ${failureInfo.message}`
-    case 'storage':
-      return `storage ${failureInfo.operation}: ${failureInfo.message}`
-    case 'publish':
-      return `publish ${failureInfo.operation}: ${failureInfo.message}`
-  }
-}
-
 export async function runDailyPluginPipeline(
   dependencies: PipelineDependencies,
   definitions: readonly PluginDefinition[],
@@ -112,72 +86,6 @@ export async function runDailyPluginPipeline(
     })
   }
 
-  // Run 生命周期：恢复同 Run 断点续传，或创建新 Run。
-  const resumable = await dependencies.store.findResumableRun()
-  if (!resumable.ok)
-    return resumable
-
-  let run: SyncRun
-  if (resumable.value.state === 'present') {
-    run = resumable.value.value
-    console.log(`[pipeline] resuming run ${run.runId} (businessDate=${run.businessDate}) at stage=${run.status === 'running' ? run.stage : 'replication'}`)
-  }
-  else {
-    const created: SyncRun = {
-      runId: randomUUID(),
-      businessDate: startedAt.slice(0, 10),
-      startedAt,
-      updatedAt: dependencies.clock.nowIso(),
-      status: 'running',
-      stage: 'replication',
-      replication: { state: 'absent' },
-    }
-    const saved = await dependencies.store.createRun(created)
-    if (!saved.ok)
-      return failure(saved.error)
-    run = saved.value
-    console.log(`[pipeline] started run ${run.runId} (businessDate=${run.businessDate})`)
-  }
-  const runIdentity = {
-    runId: run.runId,
-    businessDate: run.businessDate,
-    startedAt: run.startedAt,
-  }
-  const currentBounds = (): Presence<ReplicationBounds> => run.status === 'complete'
-    ? { state: 'present', value: run.replication }
-    : run.replication
-
-  async function advanceStage(stage: ActiveSyncStage): Promise<Result<boolean, RequestFailure>> {
-    const updated: SyncRun = {
-      ...runIdentity,
-      updatedAt: dependencies.clock.nowIso(),
-      status: 'running',
-      stage,
-      replication: currentBounds(),
-    }
-    const saved = await dependencies.store.updateRun(updated)
-    if (!saved.ok)
-      return failure(saved.error)
-    run = saved.value
-    return ok(true)
-  }
-
-  async function failRun(stage: ActiveSyncStage, failureInfo: RequestFailure): Promise<Result<CompletePluginSnapshot, RequestFailure>> {
-    const failedRun: SyncRun = {
-      ...runIdentity,
-      updatedAt: dependencies.clock.nowIso(),
-      status: 'failed',
-      failedAt: dependencies.clock.nowIso(),
-      failedStage: stage,
-      replication: currentBounds(),
-      failureMessage: describeFailure(failureInfo),
-    }
-    const saved = await dependencies.store.updateRun(failedRun)
-    if (!saved.ok)
-      console.error(`[pipeline] failed to persist run failure state`, saved.error)
-    return failure(failureInfo)
-  }
-
   // 调度器与客户端装配。
   const schedulers: Record<'replication' | 'npm-registry' | 'npm-downloads' | 'github', HostScheduler> = {
     'replication': createHostScheduler(dependencies.replicationPolicy),
@@ -185,54 +93,39 @@ export async function runDailyPluginPipeline(
     'npm-downloads': createHostScheduler(dependencies.npmDownloadsPolicy),
     'github': createHostScheduler(dependencies.githubPolicy),
   }
-  const replicationClient = createReplicationClient({
-    scheduler: schedulers.replication,
-    store: dependencies.store,
-    runId: run.runId,
-  })
+  const replicationClient = createReplicationClient({ scheduler: schedulers.replication })
   const registryClient = createRegistryClient({
     scheduler: schedulers['npm-registry'],
-    store: dependencies.store,
-    runId: run.runId,
+    cacheStore: dependencies.cacheStore,
   })
-  const downloadsClient = createDownloadsClient({
-    scheduler: schedulers['npm-downloads'],
-    store: dependencies.store,
-    runId: run.runId,
-  })
+  const downloadsClient = createDownloadsClient({ scheduler: schedulers['npm-downloads'] })
   const githubClient = createGitHubClient({
     scheduler: schedulers.github,
-    store: dependencies.store,
-    runId: run.runId,
+    cacheStore: dependencies.cacheStore,
     token: dependencies.githubToken,
   })
 
   // 阶段一：Replication 全量扫描。
-  const advancedReplication = await advanceStage('replication')
-  if (!advancedReplication.ok)
-    return failure(advancedReplication.error)
+  console.log('[pipeline] stage 1/5: replication scan')
   const replication = await replicationClient.createReplicationSnapshot(definitions)
   if (!replication.ok)
-    return failRun('replication', replication.error)
-  const savedSnapshot = await dependencies.store.saveReplicationSnapshot(run.runId, replication.value)
-  if (!savedSnapshot.ok)
-    return failRun('replication', savedSnapshot.error)
+    return failure(replication.error)
 
   // 阶段二：每日全量 Package Metadata。
-  const advancedMetadata = await advanceStage('metadata')
-  if (!advancedMetadata.ok)
-    return failure(advancedMetadata.error)
+  console.log('[pipeline] stage 2/5: package metadata checks')
   const metadata = await registryClient.fetchAllPackageMetadata(replication.value)
+  // 无论阶段成败都先落盘已获得的缓存，重跑时这些包可以走 304。
+  const metadataFlushed = dependencies.cacheStore.flush()
   if (!metadata.ok)
-    return failRun('metadata', metadata.error)
+    return failure(metadata.error)
+  if (!metadataFlushed.ok)
+    return failure(metadataFlushed.error)
 
   // 阶段三：每日全量 Downloads。
-  const advancedDownloads = await advanceStage('downloads')
-  if (!advancedDownloads.ok)
-    return failure(advancedDownloads.error)
+  console.log('[pipeline] stage 3/5: downloads')
   const periods = await downloadsClient.resolveDownloadPeriods()
   if (!periods.ok)
-    return failRun('downloads', periods.error)
+    return failure(periods.error)
   const dailyPeriod = periods.value[0]
   const monthlyPeriod = periods.value[1]
   const downloads = await downloadsClient.fetchAllDownloads(
@@ -241,30 +134,29 @@ export async function runDailyPluginPipeline(
     monthlyPeriod,
   )
   if (!downloads.ok)
-    return failRun('downloads', downloads.error)
+    return failure(downloads.error)
 
   // 阶段四：每日全量 GitHub 条件检查。
-  const advancedGithub = await advanceStage('github')
-  if (!advancedGithub.ok)
-    return failure(advancedGithub.error)
+  console.log('[pipeline] stage 4/5: github repository checks')
   const packageTargets = collectPackageGitHubTargets(metadata.value)
   if (!packageTargets.ok)
-    return failRun('github', packageTargets.error)
+    return failure(packageTargets.error)
   const repositoryTargets = collectUniqueGitHubTargets(packageTargets.value)
   if (!repositoryTargets.ok)
-    return failRun('github', repositoryTargets.error)
+    return failure(repositoryTargets.error)
   console.log(`[github] ${repositoryTargets.value.length} unique repository target(s) from ${packageTargets.value.length} package(s)`)
   const githubRecords = await githubClient.fetchAllGitHubRepositories(repositoryTargets.value)
+  const githubFlushed = dependencies.cacheStore.flush()
   if (!githubRecords.ok)
-    return failRun('github', githubRecords.error)
+    return failure(githubRecords.error)
+  if (!githubFlushed.ok)
+    return failure(githubFlushed.error)
   const github = githubClient.mapGitHubRecordsToPackages(packageTargets.value, githubRecords.value)
   if (!github.ok)
-    return failRun('github', github.error)
+    return failure(github.error)
 
   // 阶段五：构建并发布完整快照。
-  const advancedValidation = await advanceStage('validation')
-  if (!advancedValidation.ok)
-    return failure(advancedValidation.error)
+  console.log('[pipeline] stage 5/5: validate and publish snapshot')
   const snapshot = validateCompleteSnapshot(
     replication.value,
     metadata.value,
@@ -276,34 +168,14 @@ export async function runDailyPluginPipeline(
     dependencies.clock.nowIso(),
   )
   if (!snapshot.ok)
-    return failRun('validation', snapshot.error)
+    return failure(snapshot.error)
 
-  const advancedPublishing = await advanceStage('publishing')
-  if (!advancedPublishing.ok)
-    return failure(advancedPublishing.error)
   const staged = await dependencies.publisher.writeSnapshotToStage(snapshot.value)
   if (!staged.ok)
-    return failRun('publishing', staged.error)
+    return failure(staged.error)
   const published = await dependencies.publisher.publishStage(staged.value, snapshot.value)
   if (!published.ok)
-    return failRun('publishing', published.error)
-  const savedPublished = await dependencies.store.savePublishedSnapshot(published.value, snapshot.value)
-  if (!savedPublished.ok)
-    return failRun('publishing', savedPublished.error)
-
-  const completedRun: SyncRun = {
-    ...runIdentity,
-    updatedAt: dependencies.clock.nowIso(),
-    status: 'complete',
-    completedAt: dependencies.clock.nowIso(),
-    replication: {
-      startSequence: replication.value.startSequence,
-      endSequence: replication.value.endSequence,
-    },
-  }
-  const savedRun = await dependencies.store.updateRun(completedRun)
-  if (!savedRun.ok)
-    return failure(savedRun.error)
+    return failure(published.error)
 
   console.log(`[pipeline] snapshot ${snapshot.value.snapshotId} published to ${published.value.publishedPath} with ${snapshot.value.entries.length} entries`)
   return ok(snapshot.value)

--- a/packages/generate/src/generate-plugin/pipeline.ts
+++ b/packages/generate/src/generate-plugin/pipeline.ts
@@ -1,0 +1,310 @@
+// Pipeline：严格按五个阶段编排。任何必要数据失败或缺失时，本次快照不发布。
+
+import type { PipelineClock } from './clock'
+import type { ActiveSyncStage, CompletePluginSnapshot, HostPolicy, PluginDefinition, Presence, ReplicationBounds, RequestFailure, Result, StateStore, SyncRun } from './contracts'
+import type { HostScheduler } from './host-scheduler'
+import type { SnapshotPublisher } from './snapshot-publisher'
+import { randomUUID } from 'node:crypto'
+import { isValidIsoUtcTimestamp } from './clock'
+import {
+
+  failure,
+
+  ok,
+
+} from './contracts'
+import { createGitHubClient } from './github-client'
+import { createHostScheduler } from './host-scheduler'
+import { createDownloadsClient } from './npm-downloads-client'
+import { createRegistryClient } from './npm-registry-client'
+import { createReplicationClient } from './replication-client'
+import { collectPackageGitHubTargets, collectUniqueGitHubTargets } from './repository-parser'
+import { validateCompleteSnapshot } from './snapshot-validator'
+
+export interface PipelineDependencies {
+  store: StateStore
+  clock: PipelineClock
+  replicationPolicy: HostPolicy
+  npmRegistryPolicy: HostPolicy
+  npmDownloadsPolicy: HostPolicy
+  githubPolicy: HostPolicy
+  githubToken: string
+  publisher: SnapshotPublisher
+}
+
+export const DEFAULT_HOST_POLICIES: Readonly<Record<'replication' | 'npm-registry' | 'npm-downloads' | 'github', HostPolicy>> = {
+  'replication': {
+    host: 'replication',
+    concurrency: 1,
+    intervalMs: 1000,
+    intervalCap: 2,
+    requestTimeoutMs: 30000,
+    maxAttemptsPerRun: 8,
+    circuitBreakerThreshold: 10,
+    circuitBreakerPauseMs: 180000,
+  },
+  'npm-registry': {
+    host: 'npm-registry',
+    concurrency: 3,
+    intervalMs: 1000,
+    intervalCap: 5,
+    requestTimeoutMs: 30000,
+    maxAttemptsPerRun: 8,
+    circuitBreakerThreshold: 10,
+    circuitBreakerPauseMs: 180000,
+  },
+  'npm-downloads': {
+    host: 'npm-downloads',
+    concurrency: 1,
+    intervalMs: 750,
+    intervalCap: 1,
+    requestTimeoutMs: 30000,
+    maxAttemptsPerRun: 8,
+    circuitBreakerThreshold: 10,
+    circuitBreakerPauseMs: 180000,
+  },
+  'github': {
+    host: 'github',
+    concurrency: 2,
+    intervalMs: 1000,
+    intervalCap: 2,
+    requestTimeoutMs: 30000,
+    maxAttemptsPerRun: 8,
+    circuitBreakerThreshold: 10,
+    circuitBreakerPauseMs: 180000,
+  },
+}
+
+function describeFailure(failureInfo: RequestFailure): string {
+  switch (failureInfo.kind) {
+    case 'network':
+      return `network: ${failureInfo.message}`
+    case 'timeout':
+      return `timeout after ${failureInfo.timeoutMs}ms`
+    case 'http':
+      return `http ${failureInfo.status}: ${failureInfo.body.slice(0, 200)}`
+    case 'schema':
+      return `schema: ${failureInfo.issues.join('; ')}`
+    case 'invariant':
+      return `invariant: ${failureInfo.message}`
+    case 'storage':
+      return `storage ${failureInfo.operation}: ${failureInfo.message}`
+    case 'publish':
+      return `publish ${failureInfo.operation}: ${failureInfo.message}`
+  }
+}
+
+export async function runDailyPluginPipeline(
+  dependencies: PipelineDependencies,
+  definitions: readonly PluginDefinition[],
+  startedAt: string,
+): Promise<Result<CompletePluginSnapshot, RequestFailure>> {
+  if (dependencies.githubToken.length === 0) {
+    return failure({
+      kind: 'invariant',
+      message: 'github token is required for the daily pipeline',
+    })
+  }
+  if (!isValidIsoUtcTimestamp(startedAt)) {
+    return failure({
+      kind: 'invariant',
+      message: `pipeline startedAt "${startedAt}" is not an ISO 8601 UTC timestamp`,
+    })
+  }
+
+  // Run 生命周期：恢复同 Run 断点续传，或创建新 Run。
+  const resumable = await dependencies.store.findResumableRun()
+  if (!resumable.ok)
+    return resumable
+
+  let run: SyncRun
+  if (resumable.value.state === 'present') {
+    run = resumable.value.value
+    console.log(`[pipeline] resuming run ${run.runId} (businessDate=${run.businessDate}) at stage=${run.status === 'running' ? run.stage : 'replication'}`)
+  }
+  else {
+    const created: SyncRun = {
+      runId: randomUUID(),
+      businessDate: startedAt.slice(0, 10),
+      startedAt,
+      updatedAt: dependencies.clock.nowIso(),
+      status: 'running',
+      stage: 'replication',
+      replication: { state: 'absent' },
+    }
+    const saved = await dependencies.store.createRun(created)
+    if (!saved.ok)
+      return failure(saved.error)
+    run = saved.value
+    console.log(`[pipeline] started run ${run.runId} (businessDate=${run.businessDate})`)
+  }
+  const runIdentity = {
+    runId: run.runId,
+    businessDate: run.businessDate,
+    startedAt: run.startedAt,
+  }
+  const currentBounds = (): Presence<ReplicationBounds> => run.status === 'complete'
+    ? { state: 'present', value: run.replication }
+    : run.replication
+
+  async function advanceStage(stage: ActiveSyncStage): Promise<Result<boolean, RequestFailure>> {
+    const updated: SyncRun = {
+      ...runIdentity,
+      updatedAt: dependencies.clock.nowIso(),
+      status: 'running',
+      stage,
+      replication: currentBounds(),
+    }
+    const saved = await dependencies.store.updateRun(updated)
+    if (!saved.ok)
+      return failure(saved.error)
+    run = saved.value
+    return ok(true)
+  }
+
+  async function failRun(stage: ActiveSyncStage, failureInfo: RequestFailure): Promise<Result<CompletePluginSnapshot, RequestFailure>> {
+    const failedRun: SyncRun = {
+      ...runIdentity,
+      updatedAt: dependencies.clock.nowIso(),
+      status: 'failed',
+      failedAt: dependencies.clock.nowIso(),
+      failedStage: stage,
+      replication: currentBounds(),
+      failureMessage: describeFailure(failureInfo),
+    }
+    const saved = await dependencies.store.updateRun(failedRun)
+    if (!saved.ok)
+      console.error(`[pipeline] failed to persist run failure state`, saved.error)
+    return failure(failureInfo)
+  }
+
+  // 调度器与客户端装配。
+  const schedulers: Record<'replication' | 'npm-registry' | 'npm-downloads' | 'github', HostScheduler> = {
+    'replication': createHostScheduler(dependencies.replicationPolicy),
+    'npm-registry': createHostScheduler(dependencies.npmRegistryPolicy),
+    'npm-downloads': createHostScheduler(dependencies.npmDownloadsPolicy),
+    'github': createHostScheduler(dependencies.githubPolicy),
+  }
+  const replicationClient = createReplicationClient({
+    scheduler: schedulers.replication,
+    store: dependencies.store,
+    runId: run.runId,
+  })
+  const registryClient = createRegistryClient({
+    scheduler: schedulers['npm-registry'],
+    store: dependencies.store,
+    runId: run.runId,
+  })
+  const downloadsClient = createDownloadsClient({
+    scheduler: schedulers['npm-downloads'],
+    store: dependencies.store,
+    runId: run.runId,
+  })
+  const githubClient = createGitHubClient({
+    scheduler: schedulers.github,
+    store: dependencies.store,
+    runId: run.runId,
+    token: dependencies.githubToken,
+  })
+
+  // 阶段一：Replication 全量扫描。
+  const advancedReplication = await advanceStage('replication')
+  if (!advancedReplication.ok)
+    return failure(advancedReplication.error)
+  const replication = await replicationClient.createReplicationSnapshot(definitions)
+  if (!replication.ok)
+    return failRun('replication', replication.error)
+  const savedSnapshot = await dependencies.store.saveReplicationSnapshot(run.runId, replication.value)
+  if (!savedSnapshot.ok)
+    return failRun('replication', savedSnapshot.error)
+
+  // 阶段二：每日全量 Package Metadata。
+  const advancedMetadata = await advanceStage('metadata')
+  if (!advancedMetadata.ok)
+    return failure(advancedMetadata.error)
+  const metadata = await registryClient.fetchAllPackageMetadata(replication.value)
+  if (!metadata.ok)
+    return failRun('metadata', metadata.error)
+
+  // 阶段三：每日全量 Downloads。
+  const advancedDownloads = await advanceStage('downloads')
+  if (!advancedDownloads.ok)
+    return failure(advancedDownloads.error)
+  const periods = await downloadsClient.resolveDownloadPeriods()
+  if (!periods.ok)
+    return failRun('downloads', periods.error)
+  const dailyPeriod = periods.value[0]
+  const monthlyPeriod = periods.value[1]
+  const downloads = await downloadsClient.fetchAllDownloads(
+    replication.value.packages.map(item => item.packageName),
+    dailyPeriod,
+    monthlyPeriod,
+  )
+  if (!downloads.ok)
+    return failRun('downloads', downloads.error)
+
+  // 阶段四：每日全量 GitHub 条件检查。
+  const advancedGithub = await advanceStage('github')
+  if (!advancedGithub.ok)
+    return failure(advancedGithub.error)
+  const packageTargets = collectPackageGitHubTargets(metadata.value)
+  if (!packageTargets.ok)
+    return failRun('github', packageTargets.error)
+  const repositoryTargets = collectUniqueGitHubTargets(packageTargets.value)
+  if (!repositoryTargets.ok)
+    return failRun('github', repositoryTargets.error)
+  console.log(`[github] ${repositoryTargets.value.length} unique repository target(s) from ${packageTargets.value.length} package(s)`)
+  const githubRecords = await githubClient.fetchAllGitHubRepositories(repositoryTargets.value)
+  if (!githubRecords.ok)
+    return failRun('github', githubRecords.error)
+  const github = githubClient.mapGitHubRecordsToPackages(packageTargets.value, githubRecords.value)
+  if (!github.ok)
+    return failRun('github', github.error)
+
+  // 阶段五：构建并发布完整快照。
+  const advancedValidation = await advanceStage('validation')
+  if (!advancedValidation.ok)
+    return failure(advancedValidation.error)
+  const snapshot = validateCompleteSnapshot(
+    replication.value,
+    metadata.value,
+    downloads.value,
+    github.value,
+    dailyPeriod,
+    monthlyPeriod,
+    startedAt,
+    dependencies.clock.nowIso(),
+  )
+  if (!snapshot.ok)
+    return failRun('validation', snapshot.error)
+
+  const advancedPublishing = await advanceStage('publishing')
+  if (!advancedPublishing.ok)
+    return failure(advancedPublishing.error)
+  const staged = await dependencies.publisher.writeSnapshotToStage(snapshot.value)
+  if (!staged.ok)
+    return failRun('publishing', staged.error)
+  const published = await dependencies.publisher.publishStage(staged.value, snapshot.value)
+  if (!published.ok)
+    return failRun('publishing', published.error)
+  const savedPublished = await dependencies.store.savePublishedSnapshot(published.value, snapshot.value)
+  if (!savedPublished.ok)
+    return failRun('publishing', savedPublished.error)
+
+  const completedRun: SyncRun = {
+    ...runIdentity,
+    updatedAt: dependencies.clock.nowIso(),
+    status: 'complete',
+    completedAt: dependencies.clock.nowIso(),
+    replication: {
+      startSequence: replication.value.startSequence,
+      endSequence: replication.value.endSequence,
+    },
+  }
+  const savedRun = await dependencies.store.updateRun(completedRun)
+  if (!savedRun.ok)
+    return failure(savedRun.error)
+
+  console.log(`[pipeline] snapshot ${snapshot.value.snapshotId} published to ${published.value.publishedPath} with ${snapshot.value.entries.length} entries`)
+  return ok(snapshot.value)
+}

--- a/packages/generate/src/generate-plugin/replication-client.ts
+++ b/packages/generate/src/generate-plugin/replication-client.ts
@@ -1,7 +1,7 @@
 // 阶段一：Replication 全量扫描。
 // 前缀范围过滤、最后一行 key 游标分页、changes 补齐扫描期间的增删。
 
-import type { HttpRequest, PackageTarget, PluginDefinition, Presence, ReplicationChange, ReplicationInfo, ReplicationSnapshot, RequestFailure, Result, StateStore } from './contracts'
+import type { HttpRequest, PackageTarget, PluginDefinition, Presence, ReplicationChange, ReplicationInfo, ReplicationSnapshot, RequestFailure, Result } from './contracts'
 import type { HostScheduler } from './host-scheduler'
 import {
   absent,
@@ -20,14 +20,9 @@ const PAGE_SIZE = 1000
 
 export interface ReplicationClientDependencies {
   scheduler: HostScheduler
-  store: StateStore
-  runId: string
 }
 
-function replicationRequest(
-  dependencies: ReplicationClientDependencies,
-  url: string,
-): HttpRequest {
+function replicationRequest(dependencies: ReplicationClientDependencies, url: string): HttpRequest {
   return {
     host: 'replication',
     method: 'GET',
@@ -40,45 +35,23 @@ function replicationRequest(
 async function requestReplicationBody(
   dependencies: ReplicationClientDependencies,
   url: string,
-  taskKey: string,
 ): Promise<Result<string, RequestFailure>> {
   const scheduled = await executeScheduled(replicationRequest(dependencies, url), dependencies.scheduler)
-  if (!scheduled.ok) {
-    const recorded = await dependencies.store.recordTaskFailure(
-      dependencies.runId,
-      'replication',
-      taskKey,
-      scheduled.error.attempts,
-      scheduled.error.failure,
-    )
-    if (!recorded.ok) {
-      console.error(`failed to record replication task failure for "${taskKey}"`, scheduled.error.failure)
-      return failure(recorded.error)
-    }
+  if (!scheduled.ok)
     return failure(scheduled.error.failure)
-  }
   if (scheduled.value.response.kind !== 'body') {
     return failure({
       kind: 'invariant',
       message: `replication endpoint "${url}" returned an unexpected not-modified response`,
     })
   }
-  const recorded = await dependencies.store.recordTaskSuccess(
-    dependencies.runId,
-    'replication',
-    taskKey,
-    scheduled.value.attempts,
-    scheduled.value.response.metadata.status,
-  )
-  if (!recorded.ok)
-    return failure(recorded.error)
   return ok(scheduled.value.response.body)
 }
 
 export async function fetchReplicationInfo(
   dependencies: ReplicationClientDependencies,
 ): Promise<Result<ReplicationInfo, RequestFailure>> {
-  const body = await requestReplicationBody(dependencies, `${REPLICATION_ENDPOINT}/`, 'database-info')
+  const body = await requestReplicationBody(dependencies, `${REPLICATION_ENDPOINT}/`)
   if (!body.ok)
     return body
   const decoded = decodeReplicationInfo(body.value)
@@ -119,7 +92,7 @@ export async function collectPrefixPackages(
   while (true) {
     page += 1
     const url = buildAllDocsUrl(definition, cursor)
-    const body = await requestReplicationBody(dependencies, url, `${definition.packageNamePrefix}:page:${page}`)
+    const body = await requestReplicationBody(dependencies, url)
     if (!body.ok)
       return body
     const decoded = decodeReplicationPage(body.value)
@@ -187,7 +160,7 @@ export async function fetchChangesThrough(
 
   while (since < endSequence) {
     page += 1
-    const body = await requestReplicationBody(dependencies, buildChangesUrl(since), `changes:${page}`)
+    const body = await requestReplicationBody(dependencies, buildChangesUrl(since))
     if (!body.ok)
       return body
     const decoded = decodeReplicationChangesPage(body.value)

--- a/packages/generate/src/generate-plugin/replication-client.ts
+++ b/packages/generate/src/generate-plugin/replication-client.ts
@@ -1,0 +1,311 @@
+// 阶段一：Replication 全量扫描。
+// 前缀范围过滤、最后一行 key 游标分页、changes 补齐扫描期间的增删。
+
+import type { HttpRequest, PackageTarget, PluginDefinition, Presence, ReplicationChange, ReplicationInfo, ReplicationSnapshot, RequestFailure, Result, StateStore } from './contracts'
+import type { HostScheduler } from './host-scheduler'
+import {
+  absent,
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+import { executeScheduled } from './host-scheduler'
+import { decodeReplicationChangesPage, decodeReplicationInfo, decodeReplicationPage } from './schemas'
+
+const REPLICATION_ENDPOINT = 'https://replicate.npmjs.com/registry'
+const PAGE_SIZE = 1000
+
+export interface ReplicationClientDependencies {
+  scheduler: HostScheduler
+  store: StateStore
+  runId: string
+}
+
+function replicationRequest(
+  dependencies: ReplicationClientDependencies,
+  url: string,
+): HttpRequest {
+  return {
+    host: 'replication',
+    method: 'GET',
+    url,
+    headers: [{ name: 'accept', value: 'application/json' }],
+    timeoutMs: dependencies.scheduler.policy.requestTimeoutMs,
+  }
+}
+
+async function requestReplicationBody(
+  dependencies: ReplicationClientDependencies,
+  url: string,
+  taskKey: string,
+): Promise<Result<string, RequestFailure>> {
+  const scheduled = await executeScheduled(replicationRequest(dependencies, url), dependencies.scheduler)
+  if (!scheduled.ok) {
+    const recorded = await dependencies.store.recordTaskFailure(
+      dependencies.runId,
+      'replication',
+      taskKey,
+      scheduled.error.attempts,
+      scheduled.error.failure,
+    )
+    if (!recorded.ok) {
+      console.error(`failed to record replication task failure for "${taskKey}"`, scheduled.error.failure)
+      return failure(recorded.error)
+    }
+    return failure(scheduled.error.failure)
+  }
+  if (scheduled.value.response.kind !== 'body') {
+    return failure({
+      kind: 'invariant',
+      message: `replication endpoint "${url}" returned an unexpected not-modified response`,
+    })
+  }
+  const recorded = await dependencies.store.recordTaskSuccess(
+    dependencies.runId,
+    'replication',
+    taskKey,
+    scheduled.value.attempts,
+    scheduled.value.response.metadata.status,
+  )
+  if (!recorded.ok)
+    return failure(recorded.error)
+  return ok(scheduled.value.response.body)
+}
+
+export async function fetchReplicationInfo(
+  dependencies: ReplicationClientDependencies,
+): Promise<Result<ReplicationInfo, RequestFailure>> {
+  const body = await requestReplicationBody(dependencies, `${REPLICATION_ENDPOINT}/`, 'database-info')
+  if (!body.ok)
+    return body
+  const decoded = decodeReplicationInfo(body.value)
+  if (!decoded.ok)
+    return decoded
+  if (decoded.value.databaseName !== 'registry') {
+    return failure({
+      kind: 'invariant',
+      message: `replication database name "${decoded.value.databaseName}" is not "registry"`,
+    })
+  }
+  return ok(decoded.value)
+}
+
+export function buildAllDocsUrl(
+  definition: PluginDefinition,
+  cursor: Presence<string>,
+): string {
+  const url = new URL(`${REPLICATION_ENDPOINT}/_all_docs`)
+  const startKey = cursor.state === 'present' ? cursor.value : definition.packageNamePrefix
+  url.searchParams.set('startkey', JSON.stringify(startKey))
+  url.searchParams.set('endkey', JSON.stringify(`${definition.packageNamePrefix}\uFFF0`))
+  url.searchParams.set('limit', String(cursor.state === 'present' ? PAGE_SIZE + 1 : PAGE_SIZE))
+  return url.toString()
+}
+
+// startkey 包含边界：后续页请求 PAGE_SIZE + 1，第一条仍等于上页 cursor 时才移除。
+// cursor 恰好被删除时不能盲目 skip，避免漏掉下一条。
+export async function collectPrefixPackages(
+  dependencies: ReplicationClientDependencies,
+  definition: PluginDefinition,
+): Promise<Result<readonly PackageTarget[], RequestFailure>> {
+  const targets: PackageTarget[] = []
+  const seen = new Set<string>()
+  let cursor: Presence<string> = absent()
+  let page = 0
+
+  while (true) {
+    page += 1
+    const url = buildAllDocsUrl(definition, cursor)
+    const body = await requestReplicationBody(dependencies, url, `${definition.packageNamePrefix}:page:${page}`)
+    if (!body.ok)
+      return body
+    const decoded = decodeReplicationPage(body.value)
+    if (!decoded.ok)
+      return decoded
+
+    const rows = cursor.state === 'present' && decoded.value.rows[0]?.key === cursor.value
+      ? decoded.value.rows.slice(1)
+      : decoded.value.rows
+
+    if (rows.length === 0)
+      break
+
+    let lastKey = ''
+    for (const row of rows) {
+      if (!row.packageName.startsWith(definition.packageNamePrefix)) {
+        return failure({
+          kind: 'invariant',
+          message: `replication returned a package outside the "${definition.packageNamePrefix}" prefix: ${row.packageName}`,
+        })
+      }
+      if (seen.has(row.packageName))
+        continue
+      seen.add(row.packageName)
+      targets.push({
+        packageName: row.packageName,
+        revision: row.revision,
+        definition,
+      })
+      lastKey = row.key
+    }
+
+    if (lastKey.length === 0) {
+      return failure({
+        kind: 'invariant',
+        message: `replication page for prefix "${definition.packageNamePrefix}" produced no usable cursor`,
+      })
+    }
+
+    cursor = present(lastKey)
+    const requestedLimit = page === 1 ? PAGE_SIZE : PAGE_SIZE + 1
+    if (decoded.value.rows.length < requestedLimit)
+      break
+  }
+
+  targets.sort((left, right) => left.packageName.localeCompare(right.packageName))
+  return ok(targets)
+}
+
+export function buildChangesUrl(since: number): string {
+  const url = new URL(`${REPLICATION_ENDPOINT}/_changes`)
+  url.searchParams.set('since', String(since))
+  url.searchParams.set('limit', String(PAGE_SIZE))
+  return url.toString()
+}
+
+export async function fetchChangesThrough(
+  dependencies: ReplicationClientDependencies,
+  startSequence: number,
+  endSequence: number,
+): Promise<Result<readonly ReplicationChange[], RequestFailure>> {
+  const collected: ReplicationChange[] = []
+  let since = startSequence
+  let page = 0
+
+  while (since < endSequence) {
+    page += 1
+    const body = await requestReplicationBody(dependencies, buildChangesUrl(since), `changes:${page}`)
+    if (!body.ok)
+      return body
+    const decoded = decodeReplicationChangesPage(body.value)
+    if (!decoded.ok)
+      return decoded
+
+    for (const change of decoded.value.changes) {
+      if (change.sequence <= startSequence)
+        continue
+      if (change.sequence > endSequence)
+        continue
+      collected.push(change)
+    }
+
+    if (decoded.value.lastSequence <= since) {
+      return failure({
+        kind: 'invariant',
+        message: `replication changes cursor did not advance beyond ${since}`,
+      })
+    }
+    since = decoded.value.lastSequence
+  }
+
+  return ok(collected)
+}
+
+// createReplicationSnapshot 算法：
+// 1. 读取 startSequence；2. 顺序扫描全部前缀；3. 读取 endSequence；
+// 4. 获取 (startSequence, endSequence] 内全部 changes；
+// 5. 新增与更新 upsert，deleted 删除；6. 按 package name 去重；
+// 7. 验证每个结果都满足对应前缀；8. 排序后返回不可变 ReplicationSnapshot。
+export async function createReplicationSnapshot(
+  dependencies: ReplicationClientDependencies,
+  definitions: readonly PluginDefinition[],
+): Promise<Result<ReplicationSnapshot, RequestFailure>> {
+  const startInfo = await fetchReplicationInfo(dependencies)
+  if (!startInfo.ok)
+    return startInfo
+  const startSequence = startInfo.value.updateSequence
+  console.log(`[replication] scan started at update_seq=${startSequence}`)
+
+  const collected: PackageTarget[] = []
+  for (const definition of definitions) {
+    const prefixTargets = await collectPrefixPackages(dependencies, definition)
+    if (!prefixTargets.ok)
+      return prefixTargets
+    collected.push(...prefixTargets.value)
+    console.log(`[replication] prefix "${definition.packageNamePrefix}" matched ${prefixTargets.value.length} package(s)`)
+  }
+
+  const endInfo = await fetchReplicationInfo(dependencies)
+  if (!endInfo.ok)
+    return endInfo
+  const endSequence = endInfo.value.updateSequence
+
+  const changes = await fetchChangesThrough(dependencies, startSequence, endSequence)
+  if (!changes.ok)
+    return changes
+
+  const unique = new Map<string, PackageTarget>()
+  for (const target of collected) {
+    const existing = unique.get(target.packageName)
+    if (existing) {
+      if (existing.definition.packageNamePrefix !== target.definition.packageNamePrefix) {
+        return failure({
+          kind: 'invariant',
+          message: `package "${target.packageName}" matched multiple plugin definitions`,
+        })
+      }
+      continue
+    }
+    unique.set(target.packageName, target)
+  }
+
+  let appliedChanges = 0
+  for (const change of changes.value) {
+    const definition = definitions.find(item => change.packageName.startsWith(item.packageNamePrefix))
+    if (typeof definition !== 'object')
+      continue
+    if (change.deleted) {
+      unique.delete(change.packageName)
+    }
+    else {
+      unique.set(change.packageName, {
+        packageName: change.packageName,
+        revision: change.revision,
+        definition,
+      })
+    }
+    appliedChanges += 1
+  }
+
+  const packages = [...unique.values()]
+  for (const target of packages) {
+    if (!target.packageName.startsWith(target.definition.packageNamePrefix)) {
+      return failure({
+        kind: 'invariant',
+        message: `package "${target.packageName}" does not satisfy its prefix "${target.definition.packageNamePrefix}"`,
+      })
+    }
+  }
+  packages.sort((left, right) => left.packageName.localeCompare(right.packageName))
+
+  console.log(`[replication] scan finished at update_seq=${endSequence}; ${changes.value.length} change(s) inspected, ${appliedChanges} applied, ${packages.length} package(s) total`)
+  return ok({
+    startSequence,
+    endSequence,
+    packages,
+  })
+}
+
+export function createReplicationClient(dependencies: ReplicationClientDependencies) {
+  return {
+    fetchReplicationInfo: () => fetchReplicationInfo(dependencies),
+    collectPrefixPackages: (definition: PluginDefinition) => collectPrefixPackages(dependencies, definition),
+    fetchChangesThrough: (startSequence: number, endSequence: number) =>
+      fetchChangesThrough(dependencies, startSequence, endSequence),
+    createReplicationSnapshot: (definitions: readonly PluginDefinition[]) =>
+      createReplicationSnapshot(dependencies, definitions),
+  }
+}

--- a/packages/generate/src/generate-plugin/repository-parser.ts
+++ b/packages/generate/src/generate-plugin/repository-parser.ts
@@ -1,0 +1,181 @@
+// 从 npm metadata 中识别并规范化 GitHub 仓库。
+// 优先级：repository -> homepage -> bugsUrl。
+// 没有可识别的 GitHub 链接是合法 absent；明显声明为 GitHub 链接但无法解析是 invariant failure。
+
+import type { GitHubRepositoryTarget, PackageGitHubTarget, PackageMetadata, PackageMetadataRecord, RequestFailure, Result } from './contracts'
+import {
+  failure,
+
+  ok,
+
+} from './contracts'
+
+type ParsedGitHubSource
+  = | { kind: 'target', target: GitHubRepositoryTarget }
+    | { kind: 'invalid' }
+    | { kind: 'not-github' }
+
+const OWNER_PATTERN = /^[A-Z0-9](?:[A-Z0-9-]*[A-Z0-9])?$/i
+const REPOSITORY_PATTERN = /^[\w.-]+$/
+
+function stripGitSuffix(value: string): string {
+  if (value.endsWith('.git'))
+    return value.slice(0, -4)
+  return value
+}
+
+function stripHashSuffix(value: string): string {
+  const hashIndex = value.indexOf('#')
+  if (hashIndex >= 0)
+    return value.slice(0, hashIndex)
+  return value
+}
+
+function targetFromSlug(slug: string): ParsedGitHubSource {
+  const working = stripGitSuffix(stripHashSuffix(slug.trim()))
+  const separatorIndex = working.indexOf('/')
+  if (separatorIndex <= 0 || separatorIndex === working.length - 1)
+    return { kind: 'invalid' }
+  const owner = working.slice(0, separatorIndex)
+  const repositoryPart = working.slice(separatorIndex + 1)
+  const firstPathSegment = repositoryPart.split('/')[0]
+  if (typeof firstPathSegment !== 'string' || firstPathSegment.length === 0)
+    return { kind: 'invalid' }
+  const repository = stripGitSuffix(firstPathSegment)
+  if (!OWNER_PATTERN.test(owner) || owner.includes('--'))
+    return { kind: 'invalid' }
+  if (!REPOSITORY_PATTERN.test(repository) || repository === '.' || repository === '..')
+    return { kind: 'invalid' }
+  return {
+    kind: 'target',
+    target: {
+      fullName: `${owner}/${repository}`,
+      owner,
+      repository,
+    },
+  }
+}
+
+function targetFromWebUrl(source: string): ParsedGitHubSource {
+  let url: URL
+  try {
+    url = new URL(source)
+  }
+  catch {
+    return { kind: 'invalid' }
+  }
+  if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com')
+    return { kind: 'not-github' }
+  const segments = url.pathname.split('/').filter(segment => segment.length > 0)
+  const rawOwner = segments[0]
+  const rawRepository = segments[1]
+  if (typeof rawOwner !== 'string' || typeof rawRepository !== 'string')
+    return { kind: 'invalid' }
+  const repository = stripGitSuffix(rawRepository)
+  if (!OWNER_PATTERN.test(rawOwner) || rawOwner.includes('--'))
+    return { kind: 'invalid' }
+  if (!REPOSITORY_PATTERN.test(repository) || repository === '.' || repository === '..')
+    return { kind: 'invalid' }
+  return {
+    kind: 'target',
+    target: {
+      fullName: `${rawOwner}/${repository}`,
+      owner: rawOwner,
+      repository,
+    },
+  }
+}
+
+function parseGitHubSource(source: string): ParsedGitHubSource {
+  const trimmed = source.trim()
+  if (trimmed.length === 0)
+    return { kind: 'not-github' }
+
+  if (trimmed.startsWith('github:'))
+    return targetFromSlug(trimmed.slice('github:'.length))
+  if (trimmed.startsWith('git@github.com:'))
+    return targetFromSlug(trimmed.slice('git@github.com:'.length))
+
+  let working = trimmed
+  if (working.startsWith('git+'))
+    working = working.slice(4)
+  if (working.startsWith('https://') || working.startsWith('http://') || working.startsWith('git://'))
+    return targetFromWebUrl(working)
+
+  // 非协议形式：仅当字面量明显指向 github 时才是 declared 链接。
+  if (trimmed.includes('github.com'))
+    return targetFromWebUrl(trimmed)
+  if (/^[\w.-]+\/[\w.-]+/.test(trimmed))
+    return targetFromSlug(trimmed)
+  return { kind: 'not-github' }
+}
+
+interface MetadataSourceCandidate {
+  origin: 'repository' | 'homepage' | 'bugsUrl'
+  value: string
+}
+
+function collectSourceCandidates(metadata: PackageMetadata): readonly MetadataSourceCandidate[] {
+  const candidates: MetadataSourceCandidate[] = []
+  if (metadata.repository.state === 'present') {
+    const repository = metadata.repository.value
+    candidates.push({
+      origin: 'repository',
+      value: repository.kind === 'string' ? repository.value : repository.url,
+    })
+  }
+  if (metadata.homepage.state === 'present')
+    candidates.push({ origin: 'homepage', value: metadata.homepage.value })
+  if (metadata.bugsUrl.state === 'present')
+    candidates.push({ origin: 'bugsUrl', value: metadata.bugsUrl.value })
+  return candidates
+}
+
+export function extractGitHubTarget(metadata: PackageMetadata): Result<PackageGitHubTarget, RequestFailure> {
+  for (const candidate of collectSourceCandidates(metadata)) {
+    const parsed = parseGitHubSource(candidate.value)
+    if (parsed.kind === 'target') {
+      return ok({
+        kind: 'repository',
+        packageName: metadata.name,
+        target: parsed.target,
+      })
+    }
+    if (parsed.kind === 'invalid') {
+      return failure({
+        kind: 'invariant',
+        message: `package "${metadata.name}" declares an unparseable GitHub URL in ${candidate.origin}: ${candidate.value}`,
+      })
+    }
+  }
+  return ok({ kind: 'absent', packageName: metadata.name })
+}
+
+export function collectPackageGitHubTargets(
+  metadataRecords: readonly PackageMetadataRecord[],
+): Result<readonly PackageGitHubTarget[], RequestFailure> {
+  const targets: PackageGitHubTarget[] = []
+  for (const record of metadataRecords) {
+    const extracted = extractGitHubTarget(record.metadata)
+    if (!extracted.ok)
+      return extracted
+    targets.push(extracted.value)
+  }
+  return ok(targets)
+}
+
+export function collectUniqueGitHubTargets(
+  packageTargets: readonly PackageGitHubTarget[],
+): Result<readonly GitHubRepositoryTarget[], RequestFailure> {
+  const unique = new Map<string, GitHubRepositoryTarget>()
+  for (const target of packageTargets) {
+    if (target.kind !== 'repository')
+      continue
+    const key = target.target.fullName.toLowerCase()
+    if (!unique.has(key))
+      unique.set(key, target.target)
+  }
+  const collected = [...unique.values()]
+  collected.sort((left, right) => left.fullName.localeCompare(right.fullName))
+  return ok(collected)
+}

--- a/packages/generate/src/generate-plugin/schemas.ts
+++ b/packages/generate/src/generate-plugin/schemas.ts
@@ -18,7 +18,6 @@ import {
 // 基础规则
 // ---------------------------------------------------------------------------
 
-const finiteNumberSchema = z.number().finite()
 const nonNegativeIntegerSchema = z.number().int().nonnegative()
 
 function isValidCalendarDate(value: string): boolean {
@@ -71,7 +70,6 @@ function presenceSchema<T>(inner: z.ZodType<T>): z.ZodType<Presence<T>> {
 
 const presenceStringSchema = presenceSchema(z.string())
 const presenceStringArraySchema = presenceSchema(z.array(z.string()))
-const presenceNumberSchema = presenceSchema(finiteNumberSchema)
 
 // ---------------------------------------------------------------------------
 // Replication
@@ -441,90 +439,13 @@ export function decodeGitHubRepository(
 }
 
 // ---------------------------------------------------------------------------
-// 同步 Run / Task / RequestFailure（存储往返）
+// 快照文件与 manifest
 // ---------------------------------------------------------------------------
-
-export const replicationBoundsSchema = z.object({
-  startSequence: nonNegativeIntegerSchema,
-  endSequence: nonNegativeIntegerSchema,
-})
-
-const presenceReplicationBoundsSchema = presenceSchema(replicationBoundsSchema)
-
-const activeSyncStageSchema = z.enum(['replication', 'metadata', 'downloads', 'github', 'validation', 'publishing'])
 
 const isoUtcTimestampSchema = z.string().refine(
   value => /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value) && Number.isFinite(Date.parse(value)),
   { message: 'expected an ISO 8601 UTC timestamp' },
 )
-
-const syncRunIdentityFields = {
-  runId: z.string().min(1),
-  businessDate: isoDateStringSchema,
-  startedAt: isoUtcTimestampSchema,
-  updatedAt: isoUtcTimestampSchema,
-}
-
-export const syncRunSchema = z.discriminatedUnion('status', [
-  z.object({
-    ...syncRunIdentityFields,
-    status: z.literal('running'),
-    stage: activeSyncStageSchema,
-    replication: presenceReplicationBoundsSchema,
-  }),
-  z.object({
-    ...syncRunIdentityFields,
-    status: z.literal('complete'),
-    completedAt: isoUtcTimestampSchema,
-    replication: replicationBoundsSchema,
-  }),
-  z.object({
-    ...syncRunIdentityFields,
-    status: z.literal('failed'),
-    failedAt: isoUtcTimestampSchema,
-    failedStage: activeSyncStageSchema,
-    replication: presenceReplicationBoundsSchema,
-    failureMessage: z.string().min(1),
-  }),
-])
-
-export const requestFailureSchema = z.discriminatedUnion('kind', [
-  z.object({ kind: z.literal('network'), message: z.string() }),
-  z.object({ kind: z.literal('timeout'), timeoutMs: nonNegativeIntegerSchema }),
-  z.object({
-    kind: z.literal('http'),
-    status: nonNegativeIntegerSchema,
-    body: z.string(),
-    retryAfterMs: presenceNumberSchema,
-    rateLimitRemaining: presenceNumberSchema,
-    rateLimitResetAt: presenceNumberSchema,
-  }),
-  z.object({ kind: z.literal('schema'), issues: z.array(z.string()) }),
-  z.object({ kind: z.literal('invariant'), message: z.string() }),
-  z.object({ kind: z.literal('storage'), operation: z.string().min(1), message: z.string() }),
-  z.object({ kind: z.literal('publish'), operation: z.string().min(1), message: z.string() }),
-])
-
-export const syncTaskStatusSchema = z.enum(['pending', 'running', 'retry-wait', 'success', 'failed'])
-
-const syncTaskDetailSchema = z.object({
-  completedAt: z.optional(isoUtcTimestampSchema),
-  responseStatus: z.optional(nonNegativeIntegerSchema),
-  failure: z.optional(requestFailureSchema),
-})
-
-export const storedTaskSummarySchema = z.object({
-  source: z.enum(['replication', 'npm-registry', 'npm-downloads', 'github']),
-  taskKey: z.string().min(1),
-  status: syncTaskStatusSchema,
-  detail: syncTaskDetailSchema,
-})
-
-export type StoredTaskDetail = z.infer<typeof storedTaskSummarySchema>
-
-// ---------------------------------------------------------------------------
-// 快照文件与 manifest
-// ---------------------------------------------------------------------------
 
 const downloadPeriodSchema = z.object({
   kind: z.enum(['daily', 'monthly']),

--- a/packages/generate/src/generate-plugin/schemas.ts
+++ b/packages/generate/src/generate-plugin/schemas.ts
@@ -1,0 +1,573 @@
+// 外部 JSON 的运行时 schema 与解码函数。
+// schema 失败产生 RequestFailure.kind === 'schema'，并阻止快照发布。
+
+import type { DownloadPeriod, DownloadPoint, GitHubRepositoryData, NpmRepository, PackageMetadata, Presence, ReplicationChange, ReplicationChangesPage, ReplicationIndexRow, ReplicationInfo, ReplicationPage, RequestFailure, Result } from './contracts'
+import { z } from 'zod'
+import {
+  absent,
+
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+
+// ---------------------------------------------------------------------------
+// 基础规则
+// ---------------------------------------------------------------------------
+
+const finiteNumberSchema = z.number().finite()
+const nonNegativeIntegerSchema = z.number().int().nonnegative()
+
+function isValidCalendarDate(value: string): boolean {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match)
+    return false
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  if (!Number.isSafeInteger(year) || !Number.isSafeInteger(month) || !Number.isSafeInteger(day))
+    return false
+  if (month < 1 || month > 12 || day < 1 || day > 31)
+    return false
+  const timestamp = Date.UTC(year, month - 1, day)
+  const roundTrip = new Date(timestamp)
+  return roundTrip.getUTCFullYear() === year
+    && roundTrip.getUTCMonth() === month - 1
+    && roundTrip.getUTCDate() === day
+}
+
+const isoDateStringSchema = z.string().refine(isValidCalendarDate, { message: 'expected a valid YYYY-MM-DD calendar date' })
+
+const responseHashSchema = z.string().regex(/^[0-9a-f]{64}$/, { message: 'expected a lowercase sha-256 hex digest' })
+
+function collectIssues(error: z.ZodError): readonly string[] {
+  return error.issues.map(issue => `${issue.path.join('.')}: ${issue.message}`)
+}
+
+function schemaFailure(error: z.ZodError): RequestFailure {
+  return { kind: 'schema', issues: collectIssues(error) }
+}
+
+function decodeBody<T>(schema: z.ZodType<T>, body: string): Result<T, RequestFailure> {
+  const parsed = schema.safeParse(JSON.parse(body))
+  if (!parsed.success)
+    return failure(schemaFailure(parsed.error))
+  return ok(parsed.data)
+}
+
+// ---------------------------------------------------------------------------
+// 序列化形态的 Presence（用于存储往返与快照文件校验）
+// ---------------------------------------------------------------------------
+
+function presenceSchema<T>(inner: z.ZodType<T>): z.ZodType<Presence<T>> {
+  return z.union([
+    z.object({ state: z.literal('present'), value: inner }),
+    z.object({ state: z.literal('absent') }),
+  ])
+}
+
+const presenceStringSchema = presenceSchema(z.string())
+const presenceStringArraySchema = presenceSchema(z.array(z.string()))
+const presenceNumberSchema = presenceSchema(finiteNumberSchema)
+
+// ---------------------------------------------------------------------------
+// Replication
+// ---------------------------------------------------------------------------
+
+const replicationInfoWireSchema = z.object({
+  db_name: z.string().min(1),
+  engine: z.string().min(1),
+  doc_count: nonNegativeIntegerSchema,
+  update_seq: nonNegativeIntegerSchema,
+})
+
+const replicationPageWireSchema = z.object({
+  total_rows: nonNegativeIntegerSchema,
+  offset: nonNegativeIntegerSchema,
+  rows: z.array(z.object({
+    id: z.string().min(1),
+    key: z.string().min(1),
+    value: z.object({
+      rev: z.string().min(1),
+    }),
+  })),
+})
+
+const replicationChangesPageWireSchema = z.object({
+  last_seq: nonNegativeIntegerSchema,
+  results: z.array(z.object({
+    seq: nonNegativeIntegerSchema,
+    id: z.string().min(1),
+    changes: z.array(z.object({ rev: z.string().min(1) })).min(1),
+    deleted: z.optional(z.boolean()),
+  })),
+})
+
+export function decodeReplicationInfo(body: string): Result<ReplicationInfo, RequestFailure> {
+  const decoded = decodeBody(replicationInfoWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  return ok({
+    databaseName: decoded.value.db_name,
+    engine: decoded.value.engine,
+    documentCount: decoded.value.doc_count,
+    updateSequence: decoded.value.update_seq,
+  })
+}
+
+export function decodeReplicationPage(body: string): Result<ReplicationPage, RequestFailure> {
+  const decoded = decodeBody(replicationPageWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  const rows: ReplicationIndexRow[] = decoded.value.rows.map(row => ({
+    packageName: row.id,
+    key: row.key,
+    revision: row.value.rev,
+  }))
+  return ok({
+    totalRows: decoded.value.total_rows,
+    offset: decoded.value.offset,
+    rows,
+  })
+}
+
+export function decodeReplicationChangesPage(body: string): Result<ReplicationChangesPage, RequestFailure> {
+  const decoded = decodeBody(replicationChangesPageWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  const changes: ReplicationChange[] = []
+  for (const row of decoded.value.results) {
+    const firstRevision = row.changes[0]?.rev
+    if (typeof firstRevision !== 'string') {
+      return failure({
+        kind: 'schema',
+        issues: [`changes[0].rev is missing for replication change "${row.id}"`],
+      })
+    }
+    changes.push({
+      sequence: row.seq,
+      packageName: row.id,
+      revision: firstRevision,
+      deleted: row.deleted === true,
+    })
+  }
+  return ok({
+    lastSequence: decoded.value.last_seq,
+    changes,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Package metadata
+// ---------------------------------------------------------------------------
+
+const npmRepositoryWireSchema = z.union([
+  z.string().min(1),
+  z.object({
+    url: z.string().min(1),
+    type: z.optional(z.string()),
+    directory: z.optional(z.string()),
+  }),
+])
+
+const packageMetadataWireSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1),
+  description: z.optional(z.string()),
+  keywords: z.optional(z.array(z.string())),
+  repository: z.optional(npmRepositoryWireSchema),
+  homepage: z.optional(z.string()),
+  bugs: z.optional(z.object({
+    url: z.optional(z.string().min(1)),
+  })),
+  deprecated: z.optional(z.string()),
+})
+
+export const npmRepositorySchema = z.discriminatedUnion('kind', [
+  z.object({
+    kind: z.literal('string'),
+    value: z.string().min(1),
+  }),
+  z.object({
+    kind: z.literal('object'),
+    url: z.string().min(1),
+    type: presenceStringSchema,
+    directory: presenceStringSchema,
+  }),
+])
+
+export const packageMetadataSchema = z.object({
+  name: z.string().min(1),
+  version: z.string().min(1),
+  description: presenceStringSchema,
+  keywords: presenceStringArraySchema,
+  repository: presenceSchema(npmRepositorySchema),
+  homepage: presenceStringSchema,
+  bugsUrl: presenceStringSchema,
+  deprecated: presenceStringSchema,
+})
+
+type NpmRepositoryWire = z.infer<typeof packageMetadataWireSchema>['repository']
+
+function buildNpmRepository(source: NpmRepositoryWire): Presence<NpmRepository> {
+  if (typeof source === 'string')
+    return present({ kind: 'string', value: source })
+  if (typeof source === 'object') {
+    return present({
+      kind: 'object',
+      url: source.url,
+      type: typeof source.type === 'string' ? present(source.type) : absent(),
+      directory: typeof source.directory === 'string' ? present(source.directory) : absent(),
+    })
+  }
+  return absent()
+}
+
+type PackageMetadataWire = z.infer<typeof packageMetadataWireSchema>
+
+function buildPackageMetadata(wire: PackageMetadataWire): PackageMetadata {
+  return {
+    name: wire.name,
+    version: wire.version,
+    description: typeof wire.description === 'string' ? present(wire.description) : absent(),
+    keywords: Array.isArray(wire.keywords) ? present([...wire.keywords]) : absent(),
+    repository: buildNpmRepository(wire.repository),
+    homepage: typeof wire.homepage === 'string' ? present(wire.homepage) : absent(),
+    bugsUrl: resolveBugsUrl(wire.bugs),
+    deprecated: typeof wire.deprecated === 'string' ? present(wire.deprecated) : absent(),
+  }
+}
+
+function resolveBugsUrl(bugs: PackageMetadataWire['bugs']): Presence<string> {
+  if (typeof bugs === 'object' && typeof bugs.url === 'string')
+    return present(bugs.url)
+  return absent()
+}
+
+export function decodePackageMetadata(
+  body: string,
+  expectedPackageName: string,
+): Result<PackageMetadata, RequestFailure> {
+  const parsed = packageMetadataWireSchema.safeParse(JSON.parse(body))
+  if (!parsed.success)
+    return failure(schemaFailure(parsed.error))
+  const metadata = buildPackageMetadata(parsed.data)
+  if (metadata.name !== expectedPackageName) {
+    return failure({
+      kind: 'invariant',
+      message: `npm metadata entity "${metadata.name}" does not match the requested package "${expectedPackageName}"`,
+    })
+  }
+  const validated = packageMetadataSchema.safeParse(metadata)
+  if (!validated.success)
+    return failure(schemaFailure(validated.error))
+  return ok(validated.data)
+}
+
+// 存储往返：PackageMetadataCache 的序列化校验。
+export const packageMetadataCacheSchema = z.object({
+  packageName: z.string().min(1),
+  requestUrl: z.string().min(1),
+  lastModified: presenceStringSchema,
+  responseHash: responseHashSchema,
+  metadata: packageMetadataSchema,
+})
+
+// ---------------------------------------------------------------------------
+// Downloads
+// ---------------------------------------------------------------------------
+
+const downloadPointWireSchema = z.object({
+  downloads: nonNegativeIntegerSchema,
+  package: z.string().min(1),
+  start: isoDateStringSchema,
+  end: isoDateStringSchema,
+})
+
+function buildDownloadPoint(wire: z.infer<typeof downloadPointWireSchema>): DownloadPoint {
+  return {
+    packageName: wire.package,
+    downloads: wire.downloads,
+    start: wire.start,
+    end: wire.end,
+  }
+}
+
+// 周期锚定请求：只校验实体形状与包名，不校验统计周期。
+export function decodeAnchorDownloadPoint(
+  body: string,
+  expectedPackageName: string,
+): Result<DownloadPoint, RequestFailure> {
+  const decoded = decodeBody(downloadPointWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  if (decoded.value.package !== expectedPackageName) {
+    return failure({
+      kind: 'invariant',
+      message: `npm downloads anchor entity "${decoded.value.package}" does not match the requested package "${expectedPackageName}"`,
+    })
+  }
+  return ok(buildDownloadPoint(decoded.value))
+}
+
+function rejectPeriodMismatch(
+  point: DownloadPoint,
+  expectedPeriod: DownloadPeriod,
+): Result<boolean, RequestFailure> {
+  if (point.start !== expectedPeriod.start || point.end !== expectedPeriod.end) {
+    return failure({
+      kind: 'invariant',
+      message: `npm downloads period for "${point.packageName}" (${point.start}..${point.end}) does not match the anchored period (${expectedPeriod.start}..${expectedPeriod.end})`,
+    })
+  }
+  return ok(true)
+}
+
+export function decodeDownloadPoint(
+  body: string,
+  expectedPackageName: string,
+  expectedPeriod: DownloadPeriod,
+): Result<DownloadPoint, RequestFailure> {
+  const decoded = decodeBody(downloadPointWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  if (decoded.value.package !== expectedPackageName) {
+    return failure({
+      kind: 'invariant',
+      message: `npm downloads entity "${decoded.value.package}" does not match the requested package "${expectedPackageName}"`,
+    })
+  }
+  const point = buildDownloadPoint(decoded.value)
+  const periodCheck = rejectPeriodMismatch(point, expectedPeriod)
+  if (!periodCheck.ok)
+    return periodCheck
+  return ok(point)
+}
+
+export function decodeDownloadBulkResponse(
+  body: string,
+  expectedPackageNames: readonly string[],
+  expectedPeriod: DownloadPeriod,
+): Result<readonly DownloadPoint[], RequestFailure> {
+  const parsed = z.record(z.string(), downloadPointWireSchema).safeParse(JSON.parse(body))
+  if (!parsed.success)
+    return failure(schemaFailure(parsed.error))
+
+  const responseKeys = Object.keys(parsed.data).sort()
+  const expectedKeys = [...expectedPackageNames].sort()
+  const responseKeySet = responseKeys.join('\u0000')
+  const expectedKeySet = expectedKeys.join('\u0000')
+  if (responseKeySet !== expectedKeySet) {
+    return failure({
+      kind: 'invariant',
+      message: `npm downloads bulk response key set does not match the requested set: requested ${expectedKeys.length} entries, received ${responseKeys.length} entries`,
+    })
+  }
+
+  const points: DownloadPoint[] = []
+  for (const packageName of expectedPackageNames) {
+    const wire = parsed.data[packageName]
+    if (typeof wire !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: `npm downloads bulk response is missing the key "${packageName}" despite a matching key set`,
+      })
+    }
+    if (wire.package !== packageName) {
+      return failure({
+        kind: 'invariant',
+        message: `npm downloads bulk entry key "${packageName}" carries entity "${wire.package}"`,
+      })
+    }
+    const point = buildDownloadPoint(wire)
+    const periodCheck = rejectPeriodMismatch(point, expectedPeriod)
+    if (!periodCheck.ok)
+      return periodCheck
+    points.push(point)
+  }
+  return ok(points)
+}
+
+// ---------------------------------------------------------------------------
+// GitHub repository
+// ---------------------------------------------------------------------------
+
+const githubRepositoryWireSchema = z.object({
+  full_name: z.string().min(1),
+  html_url: z.string().min(1),
+  stargazers_count: nonNegativeIntegerSchema,
+  archived: z.boolean(),
+  disabled: z.boolean(),
+})
+
+export const githubRepositoryDataSchema = z.object({
+  fullName: z.string().min(1),
+  htmlUrl: z.string().min(1),
+  stars: nonNegativeIntegerSchema,
+  archived: z.boolean(),
+  disabled: z.boolean(),
+})
+
+export const githubRepositoryCacheSchema = z.object({
+  fullName: z.string().min(1),
+  etag: z.string().min(1),
+  responseHash: responseHashSchema,
+  data: githubRepositoryDataSchema,
+})
+
+export function decodeGitHubRepository(
+  body: string,
+  expectedFullName: string,
+): Result<GitHubRepositoryData, RequestFailure> {
+  const decoded = decodeBody(githubRepositoryWireSchema, body)
+  if (!decoded.ok)
+    return decoded
+  if (decoded.value.full_name.toLowerCase() !== expectedFullName.toLowerCase()) {
+    return failure({
+      kind: 'invariant',
+      message: `github repository "${decoded.value.full_name}" does not match the requested repository "${expectedFullName}"`,
+    })
+  }
+  return ok({
+    fullName: decoded.value.full_name,
+    htmlUrl: decoded.value.html_url,
+    stars: decoded.value.stargazers_count,
+    archived: decoded.value.archived,
+    disabled: decoded.value.disabled,
+  })
+}
+
+// ---------------------------------------------------------------------------
+// 同步 Run / Task / RequestFailure（存储往返）
+// ---------------------------------------------------------------------------
+
+export const replicationBoundsSchema = z.object({
+  startSequence: nonNegativeIntegerSchema,
+  endSequence: nonNegativeIntegerSchema,
+})
+
+const presenceReplicationBoundsSchema = presenceSchema(replicationBoundsSchema)
+
+const activeSyncStageSchema = z.enum(['replication', 'metadata', 'downloads', 'github', 'validation', 'publishing'])
+
+const isoUtcTimestampSchema = z.string().refine(
+  value => /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?Z$/.test(value) && Number.isFinite(Date.parse(value)),
+  { message: 'expected an ISO 8601 UTC timestamp' },
+)
+
+const syncRunIdentityFields = {
+  runId: z.string().min(1),
+  businessDate: isoDateStringSchema,
+  startedAt: isoUtcTimestampSchema,
+  updatedAt: isoUtcTimestampSchema,
+}
+
+export const syncRunSchema = z.discriminatedUnion('status', [
+  z.object({
+    ...syncRunIdentityFields,
+    status: z.literal('running'),
+    stage: activeSyncStageSchema,
+    replication: presenceReplicationBoundsSchema,
+  }),
+  z.object({
+    ...syncRunIdentityFields,
+    status: z.literal('complete'),
+    completedAt: isoUtcTimestampSchema,
+    replication: replicationBoundsSchema,
+  }),
+  z.object({
+    ...syncRunIdentityFields,
+    status: z.literal('failed'),
+    failedAt: isoUtcTimestampSchema,
+    failedStage: activeSyncStageSchema,
+    replication: presenceReplicationBoundsSchema,
+    failureMessage: z.string().min(1),
+  }),
+])
+
+export const requestFailureSchema = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('network'), message: z.string() }),
+  z.object({ kind: z.literal('timeout'), timeoutMs: nonNegativeIntegerSchema }),
+  z.object({
+    kind: z.literal('http'),
+    status: nonNegativeIntegerSchema,
+    body: z.string(),
+    retryAfterMs: presenceNumberSchema,
+    rateLimitRemaining: presenceNumberSchema,
+    rateLimitResetAt: presenceNumberSchema,
+  }),
+  z.object({ kind: z.literal('schema'), issues: z.array(z.string()) }),
+  z.object({ kind: z.literal('invariant'), message: z.string() }),
+  z.object({ kind: z.literal('storage'), operation: z.string().min(1), message: z.string() }),
+  z.object({ kind: z.literal('publish'), operation: z.string().min(1), message: z.string() }),
+])
+
+export const syncTaskStatusSchema = z.enum(['pending', 'running', 'retry-wait', 'success', 'failed'])
+
+const syncTaskDetailSchema = z.object({
+  completedAt: z.optional(isoUtcTimestampSchema),
+  responseStatus: z.optional(nonNegativeIntegerSchema),
+  failure: z.optional(requestFailureSchema),
+})
+
+export const storedTaskSummarySchema = z.object({
+  source: z.enum(['replication', 'npm-registry', 'npm-downloads', 'github']),
+  taskKey: z.string().min(1),
+  status: syncTaskStatusSchema,
+  detail: syncTaskDetailSchema,
+})
+
+export type StoredTaskDetail = z.infer<typeof storedTaskSummarySchema>
+
+// ---------------------------------------------------------------------------
+// 快照文件与 manifest
+// ---------------------------------------------------------------------------
+
+const downloadPeriodSchema = z.object({
+  kind: z.enum(['daily', 'monthly']),
+  start: isoDateStringSchema,
+  end: isoDateStringSchema,
+  apiPeriod: z.string().min(1),
+})
+
+export const snapshotEntryFileSchema = z.object({
+  packageName: z.string().min(1),
+  type: z.enum(['vite-plugin', 'rollup-plugin', 'rolldown-plugin', 'unplugin']),
+  directory: z.enum(['vite', 'rollup', 'rolldown', 'unplugin']),
+  icon: z.string().min(1),
+  version: z.string().min(1),
+  description: z.optional(z.string()),
+  keywords: z.optional(z.array(z.string())),
+  repository: z.optional(z.string().min(1)),
+  homepage: z.optional(z.string()),
+  deprecated: z.optional(z.string()),
+  daily: z.object({
+    downloads: nonNegativeIntegerSchema,
+    start: isoDateStringSchema,
+    end: isoDateStringSchema,
+  }),
+  monthly: z.object({
+    downloads: nonNegativeIntegerSchema,
+    start: isoDateStringSchema,
+    end: isoDateStringSchema,
+  }),
+  github: z.optional(githubRepositoryDataSchema),
+})
+
+export const snapshotManifestSchema = z.object({
+  snapshotId: z.string().min(1),
+  status: z.literal('complete'),
+  startedAt: isoUtcTimestampSchema,
+  completedAt: isoUtcTimestampSchema,
+  entryCount: nonNegativeIntegerSchema,
+  replicationStartSequence: nonNegativeIntegerSchema,
+  replicationEndSequence: nonNegativeIntegerSchema,
+  dailyPeriod: downloadPeriodSchema,
+  monthlyPeriod: downloadPeriodSchema,
+})
+
+export const DOWNLOAD_BATCH_MAX_SIZE = 100
+export const DOWNLOAD_BATCH_MAX_URL_LENGTH = 7000

--- a/packages/generate/src/generate-plugin/snapshot-publisher.ts
+++ b/packages/generate/src/generate-plugin/snapshot-publisher.ts
@@ -1,0 +1,248 @@
+// 快照发布：staging 目录生成全部文件 -> 统计文件数 -> 内容回读校验 -> manifest -> 原子目录切换。
+// 请求失败时不创建正式目录、不覆盖旧目录；旧目录仅代表上一次已发布快照。
+
+import type { CompletePluginSnapshot, PluginSnapshotEntry, PublishedSnapshot, RequestFailure, Result } from './contracts'
+import { randomUUID } from 'node:crypto'
+import { mkdir, readdir, readFile, rename, rm, writeFile } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+import {
+
+  failure,
+  ok,
+
+} from './contracts'
+import { snapshotEntryFileSchema, snapshotManifestSchema } from './schemas'
+import { hasNodeErrorCode } from './utils'
+
+export interface SnapshotPublisherOptions {
+  packageRoot: string
+  nowIso: () => string
+}
+
+export interface SnapshotPublisher {
+  writeSnapshotToStage: (snapshot: CompletePluginSnapshot) => Promise<Result<string, RequestFailure>>
+  publishStage: (stagePath: string, snapshot: CompletePluginSnapshot) => Promise<Result<PublishedSnapshot, RequestFailure>>
+}
+
+export function snapshotOutputRelativePath(target: { packageName: string, definition: { directory: string } }): Result<string, RequestFailure> {
+  const segments = target.packageName.split('/')
+  for (const segment of segments) {
+    if (segment.length === 0 || segment === '.' || segment === '..') {
+      return failure({
+        kind: 'invariant',
+        message: `unsafe npm package name cannot be published: ${target.packageName}`,
+      })
+    }
+  }
+  const last = segments.at(-1)
+  if (typeof last !== 'string' || last.length === 0) {
+    return failure({
+      kind: 'invariant',
+      message: `npm package name has no final path segment: ${target.packageName}`,
+    })
+  }
+  const relativePath = [target.definition.directory, ...segments.slice(0, -1), `${last}.json`].join('/')
+  return ok(relativePath)
+}
+
+function publishFailure(operation: string, message: string): RequestFailure {
+  return { kind: 'publish', operation, message }
+}
+
+function renderSnapshotEntry(entry: PluginSnapshotEntry): Result<string, RequestFailure> {
+  const metadata = entry.packageMetadata.metadata
+  const filePayload = {
+    packageName: entry.target.packageName,
+    type: entry.target.definition.type,
+    directory: entry.target.definition.directory,
+    icon: entry.target.definition.icon,
+    version: metadata.version,
+    ...(metadata.description.state === 'present' ? { description: metadata.description.value } : {}),
+    ...(metadata.keywords.state === 'present' ? { keywords: [...metadata.keywords.value] } : {}),
+    ...(metadata.repository.state === 'present'
+      ? {
+          repository: metadata.repository.value.kind === 'string'
+            ? metadata.repository.value.value
+            : metadata.repository.value.url,
+        }
+      : {}),
+    ...(metadata.homepage.state === 'present' ? { homepage: metadata.homepage.value } : {}),
+    ...(metadata.deprecated.state === 'present' ? { deprecated: metadata.deprecated.value } : {}),
+    daily: {
+      downloads: entry.downloads.daily.downloads,
+      start: entry.downloads.daily.start,
+      end: entry.downloads.daily.end,
+    },
+    monthly: {
+      downloads: entry.downloads.monthly.downloads,
+      start: entry.downloads.monthly.start,
+      end: entry.downloads.monthly.end,
+    },
+    ...(entry.github.kind === 'repository'
+      ? {
+          github: {
+            fullName: entry.github.repository.data.fullName,
+            htmlUrl: entry.github.repository.data.htmlUrl,
+            stars: entry.github.repository.data.stars,
+            archived: entry.github.repository.data.archived,
+            disabled: entry.github.repository.data.disabled,
+          },
+        }
+      : {}),
+  }
+  return ok(JSON.stringify(filePayload))
+}
+
+async function countSnapshotFiles(root: string): Promise<number> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true })
+  return entries.filter(entry => entry.isFile() && entry.name !== 'snapshot.json').length
+}
+
+export function createSnapshotPublisher(options: SnapshotPublisherOptions): SnapshotPublisher {
+  const stageRoot = resolve(options.packageRoot, '.sync-work/stage')
+  const publishedRoot = resolve(options.packageRoot, 'snapshots/current_complete_snapshot')
+
+  return {
+    async writeSnapshotToStage(snapshot: CompletePluginSnapshot): Promise<Result<string, RequestFailure>> {
+      const stagePath = resolve(stageRoot, snapshot.snapshotId)
+      try {
+        await rm(stagePath, { recursive: true, force: true })
+        await mkdir(stagePath, { recursive: true })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(publishFailure('prepare-stage', error.message))
+        return failure(publishFailure('prepare-stage', 'staging directory preparation failed'))
+      }
+
+      const renderedFiles: { relativePath: string, content: string }[] = []
+      const writtenPaths = new Set<string>()
+      for (const entry of snapshot.entries) {
+        const pathResult = snapshotOutputRelativePath(entry.target)
+        if (!pathResult.ok)
+          return pathResult
+        if (writtenPaths.has(pathResult.value)) {
+          return failure(publishFailure('render-entry', `duplicate staged file path: ${pathResult.value}`))
+        }
+        writtenPaths.add(pathResult.value)
+        const rendered = renderSnapshotEntry(entry)
+        if (!rendered.ok)
+          return rendered
+        renderedFiles.push({ relativePath: pathResult.value, content: rendered.value })
+      }
+
+      try {
+        for (let start = 0; start < renderedFiles.length; start += 100) {
+          await Promise.all(renderedFiles.slice(start, start + 100).map(async (file) => {
+            const absolutePath = resolve(stagePath, file.relativePath)
+            await mkdir(dirname(absolutePath), { recursive: true })
+            await writeFile(absolutePath, file.content, { flag: 'wx' })
+          }))
+        }
+
+        const fileCount = await countSnapshotFiles(stagePath)
+        if (fileCount !== snapshot.entries.length) {
+          return failure(publishFailure(
+            'stage-file-count',
+            `staged file count (${fileCount}) does not match snapshot entry count (${snapshot.entries.length})`,
+          ))
+        }
+
+        for (const file of renderedFiles) {
+          const absolutePath = resolve(stagePath, file.relativePath)
+          const stored = await readFile(absolutePath, 'utf8')
+          const validated = snapshotEntryFileSchema.safeParse(JSON.parse(stored))
+          if (!validated.success) {
+            return failure(publishFailure(
+              'stage-entry-revalidation',
+              `staged file "${file.relativePath}" failed schema validation: ${validated.error.issues[0]?.message ?? ''}`,
+            ))
+          }
+        }
+
+        const manifest = {
+          snapshotId: snapshot.snapshotId,
+          status: 'complete',
+          startedAt: snapshot.startedAt,
+          completedAt: snapshot.completedAt,
+          entryCount: snapshot.entries.length,
+          replicationStartSequence: snapshot.replicationStartSequence,
+          replicationEndSequence: snapshot.replicationEndSequence,
+          dailyPeriod: snapshot.dailyPeriod,
+          monthlyPeriod: snapshot.monthlyPeriod,
+        }
+        const manifestCheck = snapshotManifestSchema.safeParse(manifest)
+        if (!manifestCheck.success) {
+          return failure(publishFailure(
+            'stage-manifest',
+            `snapshot manifest failed schema validation: ${manifestCheck.error.issues[0]?.message ?? ''}`,
+          ))
+        }
+        await writeFile(resolve(stagePath, 'snapshot.json'), JSON.stringify(manifest), { flag: 'wx' })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(publishFailure('write-stage', error.message))
+        return failure(publishFailure('write-stage', 'staging write failed'))
+      }
+
+      return ok(stagePath)
+    },
+
+    async publishStage(stagePath: string, snapshot: CompletePluginSnapshot): Promise<Result<PublishedSnapshot, RequestFailure>> {
+      try {
+        await mkdir(dirname(publishedRoot), { recursive: true })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(publishFailure('prepare-published-parent', error.message))
+        return failure(publishFailure('prepare-published-parent', 'published parent directory preparation failed'))
+      }
+
+      const backupPath = resolve(options.packageRoot, '.sync-work', `backup-${randomUUID()}`)
+      let hasBackup = false
+      try {
+        try {
+          await rename(publishedRoot, backupPath)
+          hasBackup = true
+        }
+        catch (error) {
+          if (error instanceof Error && !hasNodeErrorCode(error, 'ENOENT'))
+            throw error
+        }
+
+        try {
+          await rename(stagePath, publishedRoot)
+        }
+        catch (error) {
+          if (hasBackup)
+            await rename(backupPath, publishedRoot)
+          throw error
+        }
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(publishFailure('atomic-swap', error.message))
+        return failure(publishFailure('atomic-swap', 'atomic directory swap failed'))
+      }
+
+      if (hasBackup) {
+        try {
+          await rm(backupPath, { recursive: true, force: true })
+        }
+        catch (error) {
+          if (error instanceof Error)
+            return failure(publishFailure('cleanup-previous-snapshot', error.message))
+          return failure(publishFailure('cleanup-previous-snapshot', 'previous snapshot cleanup failed'))
+        }
+      }
+
+      const published: PublishedSnapshot = {
+        snapshotId: snapshot.snapshotId,
+        publishedPath: publishedRoot,
+        publishedAt: options.nowIso(),
+      }
+      return ok(published)
+    },
+  }
+}

--- a/packages/generate/src/generate-plugin/snapshot-validator.ts
+++ b/packages/generate/src/generate-plugin/snapshot-validator.ts
@@ -1,0 +1,158 @@
+// 快照全局校验：四个包集合完全相等、周期一致、无重复输出路径。
+// 只有通过校验的数据才能构造 CompletePluginSnapshot —— 该类型没有 partial、pending 或 retry 分支。
+
+import type { CompletePluginSnapshot, PackageDownloads, PackageGitHubData, PackageMetadataRecord, PluginSnapshotEntry, ReplicationSnapshot, RequestFailure, Result } from './contracts'
+import { isValidIsoUtcTimestamp } from './clock'
+import {
+
+  failure,
+  ok,
+
+} from './contracts'
+import { snapshotOutputRelativePath } from './snapshot-publisher'
+
+function samePackageNameList(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length)
+    return false
+  return left.every((value, index) => value === right[index])
+}
+
+function validateDownloadPointPeriods(
+  downloads: PackageDownloads,
+  dailyPeriod: CompletePluginSnapshot['dailyPeriod'],
+  monthlyPeriod: CompletePluginSnapshot['monthlyPeriod'],
+): Result<boolean, RequestFailure> {
+  if (downloads.daily.start !== dailyPeriod.start || downloads.daily.end !== dailyPeriod.end) {
+    return failure({
+      kind: 'invariant',
+      message: `daily downloads for "${downloads.packageName}" (${downloads.daily.start}..${downloads.daily.end}) do not match the anchored daily period (${dailyPeriod.start}..${dailyPeriod.end})`,
+    })
+  }
+  if (downloads.monthly.start !== monthlyPeriod.start || downloads.monthly.end !== monthlyPeriod.end) {
+    return failure({
+      kind: 'invariant',
+      message: `monthly downloads for "${downloads.packageName}" (${downloads.monthly.start}..${downloads.monthly.end}) do not match the anchored monthly period (${monthlyPeriod.start}..${monthlyPeriod.end})`,
+    })
+  }
+  return ok(true)
+}
+
+export function validateCompleteSnapshot(
+  replication: ReplicationSnapshot,
+  metadata: readonly PackageMetadataRecord[],
+  downloads: readonly PackageDownloads[],
+  github: readonly PackageGitHubData[],
+  dailyPeriod: CompletePluginSnapshot['dailyPeriod'],
+  monthlyPeriod: CompletePluginSnapshot['monthlyPeriod'],
+  startedAt: string,
+  completedAt: string,
+): Result<CompletePluginSnapshot, RequestFailure> {
+  if (!isValidIsoUtcTimestamp(startedAt)) {
+    return failure({
+      kind: 'invariant',
+      message: `snapshot startedAt "${startedAt}" is not an ISO 8601 UTC timestamp`,
+    })
+  }
+  if (!isValidIsoUtcTimestamp(completedAt)) {
+    return failure({
+      kind: 'invariant',
+      message: `snapshot completedAt "${completedAt}" is not an ISO 8601 UTC timestamp`,
+    })
+  }
+  if (completedAt < startedAt) {
+    return failure({
+      kind: 'invariant',
+      message: `snapshot completedAt "${completedAt}" precedes startedAt "${startedAt}"`,
+    })
+  }
+
+  const replicationNames = replication.packages.map(target => target.packageName).sort()
+  const metadataNames = metadata.map(record => record.target.packageName).sort()
+  const downloadNames = downloads.map(item => item.packageName).sort()
+  const githubNames = github.map(item => item.packageName).sort()
+
+  if (!samePackageNameList(replicationNames, metadataNames)
+    || !samePackageNameList(replicationNames, downloadNames)
+    || !samePackageNameList(replicationNames, githubNames)) {
+    return failure({
+      kind: 'invariant',
+      message: `snapshot package sets differ: replication=${replicationNames.length} metadata=${metadataNames.length} downloads=${downloadNames.length} github=${githubNames.length}`,
+    })
+  }
+
+  const downloadsMap = new Map<string, PackageDownloads>()
+  for (const item of downloads) {
+    if (downloadsMap.has(item.packageName)) {
+      return failure({
+        kind: 'invariant',
+        message: `downloads contain a duplicate entry for "${item.packageName}"`,
+      })
+    }
+    downloadsMap.set(item.packageName, item)
+  }
+
+  const githubMap = new Map<string, PackageGitHubData>()
+  for (const item of github) {
+    if (githubMap.has(item.packageName)) {
+      return failure({
+        kind: 'invariant',
+        message: `github mapping contains a duplicate entry for "${item.packageName}"`,
+      })
+    }
+    githubMap.set(item.packageName, item)
+  }
+
+  for (const item of downloads) {
+    const periodCheck = validateDownloadPointPeriods(item, dailyPeriod, monthlyPeriod)
+    if (!periodCheck.ok)
+      return periodCheck
+  }
+
+  const outputPathSet = new Set<string>()
+  for (const target of replication.packages) {
+    const pathResult = snapshotOutputRelativePath(target)
+    if (!pathResult.ok)
+      return pathResult
+    if (outputPathSet.has(pathResult.value)) {
+      return failure({
+        kind: 'invariant',
+        message: `snapshot contains a duplicate output path: ${pathResult.value}`,
+      })
+    }
+    outputPathSet.add(pathResult.value)
+  }
+
+  const metadataMap = new Map(metadata.map(record => [record.target.packageName, record]))
+  const entries: PluginSnapshotEntry[] = []
+  for (const target of replication.packages) {
+    const record = metadataMap.get(target.packageName)
+    const downloadItem = downloadsMap.get(target.packageName)
+    const githubItem = githubMap.get(target.packageName)
+    if (typeof record !== 'object' || typeof downloadItem !== 'object' || typeof githubItem !== 'object') {
+      return failure({
+        kind: 'invariant',
+        message: `assembled data for "${target.packageName}" is missing despite matching package sets`,
+      })
+    }
+    entries.push({
+      target,
+      packageMetadata: record,
+      downloads: downloadItem,
+      github: githubItem,
+    })
+  }
+
+  return ok({
+    snapshotId: `${dailyPeriod.end}-${replication.endSequence}`,
+    startedAt,
+    completedAt,
+    replicationStartSequence: replication.startSequence,
+    replicationEndSequence: replication.endSequence,
+    dailyPeriod,
+    monthlyPeriod,
+    entries,
+  })
+}

--- a/packages/generate/src/generate-plugin/state-store.ts
+++ b/packages/generate/src/generate-plugin/state-store.ts
@@ -1,0 +1,527 @@
+// 持久化状态：node:sqlite 单库存储 run、task、缓存实体与快照记录。
+// 复杂值以 JSON 列存储并通过 schema 往返校验；简单标量使用普通列。
+// 每个成功请求在事务内同时写业务实体、校验器与 task 成功状态。
+
+import type { ZodType } from 'zod'
+import type { ApiHost, CompletePluginSnapshot, DownloadPoint, GitHubRepositoryCache, GitHubRepositoryOutcome, PackageDownloads, PackageMetadataCache, PackageMetadataOutcome, PackageTarget, PluginDefinition, Presence, PublishedSnapshot, ReplicationSnapshot, RequestFailure, Result, StateStore, StoredEntityCount, StoredTaskSummary, SyncRun } from './contracts'
+import { mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import {
+  absent,
+
+  failure,
+
+  ok,
+
+  present,
+
+} from './contracts'
+import {
+  githubRepositoryCacheSchema,
+  packageMetadataCacheSchema,
+  storedTaskSummarySchema,
+  syncRunSchema,
+} from './schemas'
+
+export interface StateStoreOptions {
+  databasePath: string
+  nowIso: () => string
+}
+
+const DATABASE_SCHEMA = `
+CREATE TABLE IF NOT EXISTS sync_runs (
+  run_id TEXT PRIMARY KEY,
+  status TEXT,
+  started_at TEXT,
+  run_json TEXT
+);
+CREATE TABLE IF NOT EXISTS replication_packages (
+  run_id TEXT,
+  package_name TEXT,
+  revision TEXT,
+  directory TEXT,
+  plugin_type TEXT,
+  icon TEXT,
+  prefix TEXT,
+  PRIMARY KEY (run_id, package_name)
+);
+CREATE TABLE IF NOT EXISTS package_metadata_cache (
+  package_name TEXT PRIMARY KEY,
+  cache_json TEXT
+);
+CREATE TABLE IF NOT EXISTS download_points_working (
+  run_id TEXT,
+  period_kind TEXT,
+  package_name TEXT,
+  downloads INTEGER,
+  start_date TEXT,
+  end_date TEXT,
+  PRIMARY KEY (run_id, period_kind, package_name)
+);
+CREATE TABLE IF NOT EXISTS github_repository_cache (
+  full_name TEXT PRIMARY KEY,
+  cache_json TEXT
+);
+CREATE TABLE IF NOT EXISTS sync_tasks (
+  run_id TEXT,
+  source TEXT,
+  task_key TEXT,
+  status TEXT,
+  attempt INTEGER,
+  detail_json TEXT,
+  PRIMARY KEY (run_id, source, task_key)
+);
+CREATE TABLE IF NOT EXISTS published_snapshots (
+  snapshot_id TEXT PRIMARY KEY,
+  snapshot_json TEXT
+);
+`
+
+const DEFINITION_DIRECTORIES: readonly PluginDefinition['directory'][] = ['vite', 'rollup', 'rolldown', 'unplugin']
+const DEFINITION_TYPES: readonly PluginDefinition['type'][] = ['vite-plugin', 'rollup-plugin', 'rolldown-plugin', 'unplugin']
+
+function storageFailure(operation: string, message: string): RequestFailure {
+  return { kind: 'storage', operation, message }
+}
+
+function errorMessage(error: Error): string {
+  return error.message
+}
+
+export function openStateStore(options: StateStoreOptions): StateStore {
+  mkdirSync(dirname(options.databasePath), { recursive: true })
+  const database = new DatabaseSync(options.databasePath)
+  database.exec('PRAGMA journal_mode = WAL')
+  database.exec('PRAGMA synchronous = NORMAL')
+  database.exec(DATABASE_SCHEMA)
+
+  function withTransaction<T>(operation: () => T): T {
+    database.exec('BEGIN')
+    try {
+      const value = operation()
+      database.exec('COMMIT')
+      return value
+    }
+    catch (error) {
+      database.exec('ROLLBACK')
+      throw error
+    }
+  }
+
+  function decodeJson<T>(schema: ZodType<T>, raw: string, operation: string): Result<T, RequestFailure> {
+    if (typeof raw !== 'string')
+      return failure(storageFailure(operation, 'stored payload is not a json string'))
+    let parsedValue: object
+    try {
+      parsedValue = JSON.parse(raw)
+    }
+    catch (error) {
+      if (error instanceof Error)
+        return failure(storageFailure(operation, `stored json is not parseable: ${errorMessage(error)}`))
+      return failure(storageFailure(operation, 'stored json is not parseable'))
+    }
+    const validated = schema.safeParse(parsedValue)
+    if (!validated.success) {
+      return failure(storageFailure(operation, `stored json failed schema validation: ${validated.error.issues[0]?.message ?? ''}`))
+    }
+    return ok(validated.data)
+  }
+
+  function readTextRows(sql: string, parameters: readonly string[], operation: string): Result<readonly string[], RequestFailure> {
+    try {
+      const rows = database.prepare(sql).all(...parameters)
+      const payloads: string[] = []
+      for (const row of rows) {
+        const payload = (row as Record<string, object>).payload
+        if (typeof payload !== 'string')
+          return failure(storageFailure(operation, 'stored row payload is not a string'))
+        payloads.push(payload)
+      }
+      return ok(payloads)
+    }
+    catch (error) {
+      if (error instanceof Error)
+        return failure(storageFailure(operation, errorMessage(error)))
+      return failure(storageFailure(operation, 'database read failed'))
+    }
+  }
+
+  function readAllJson<T>(schema: ZodType<T>, sql: string, operation: string): Result<readonly T[], RequestFailure> {
+    const payloads = readTextRows(sql, [], operation)
+    if (!payloads.ok)
+      return payloads
+    const decoded: T[] = []
+    for (const payload of payloads.value) {
+      const entry = decodeJson(schema, payload, operation)
+      if (!entry.ok)
+        return entry
+      decoded.push(entry.value)
+    }
+    return ok(decoded)
+  }
+
+  function readSingleJson<T>(schema: ZodType<T>, sql: string, parameters: readonly string[], operation: string): Result<Presence<T>, RequestFailure> {
+    try {
+      const row = database.prepare(sql).get(...parameters) as Record<string, object> | void
+      if (typeof row !== 'object')
+        return ok(absent<T>())
+      const payload = row.payload
+      if (typeof payload !== 'string')
+        return failure(storageFailure(operation, 'stored row payload is not a string'))
+      const decoded = decodeJson(schema, payload, operation)
+      if (!decoded.ok)
+        return failure(decoded.error)
+      return ok(present(decoded.value))
+    }
+    catch (error) {
+      if (error instanceof Error)
+        return failure(storageFailure(operation, errorMessage(error)))
+      return failure(storageFailure(operation, 'database read failed'))
+    }
+  }
+
+  const store: StateStore = {
+    readPackageMetadataCaches(): Promise<Result<readonly PackageMetadataCache[], RequestFailure>> {
+      return Promise.resolve(readAllJson(
+        packageMetadataCacheSchema,
+        'SELECT cache_json AS payload FROM package_metadata_cache ORDER BY package_name',
+        'read-package-metadata-caches',
+      ))
+    },
+
+    readGitHubCaches(): Promise<Result<readonly GitHubRepositoryCache[], RequestFailure>> {
+      return Promise.resolve(readAllJson(
+        githubRepositoryCacheSchema,
+        'SELECT cache_json AS payload FROM github_repository_cache ORDER BY full_name',
+        'read-github-caches',
+      ))
+    },
+
+    readWorkingDownloadPoints(runId: string): Promise<Result<readonly DownloadPoint[], RequestFailure>> {
+      try {
+        const rows = database
+          .prepare('SELECT package_name, downloads, start_date, end_date FROM download_points_working WHERE run_id = ?')
+          .all(runId) as Record<string, object>[]
+        const points: DownloadPoint[] = []
+        for (const row of rows) {
+          const packageName = row.package_name
+          const downloads = row.downloads
+          const startDate = row.start_date
+          const endDate = row.end_date
+          if (typeof packageName !== 'string' || typeof downloads !== 'number' || typeof startDate !== 'string' || typeof endDate !== 'string')
+            return Promise.resolve(failure(storageFailure('read-working-download-points', 'stored download point row has unexpected column types')))
+          if (!Number.isSafeInteger(downloads) || downloads < 0)
+            return Promise.resolve(failure(storageFailure('read-working-download-points', `stored download count for "${packageName}" is not a non-negative integer`)))
+          points.push({ packageName, downloads, start: startDate, end: endDate })
+        }
+        return Promise.resolve(ok(points))
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return Promise.resolve(failure(storageFailure('read-working-download-points', errorMessage(error))))
+        return Promise.resolve(failure(storageFailure('read-working-download-points', 'database read failed')))
+      }
+    },
+
+    readReplicationSnapshot(runId: string): Promise<Result<Presence<readonly PackageTarget[]>, RequestFailure>> {
+      try {
+        const rows = database
+          .prepare('SELECT package_name, revision, directory, plugin_type, icon, prefix FROM replication_packages WHERE run_id = ? ORDER BY package_name')
+          .all(runId) as Record<string, object>[]
+        if (rows.length === 0)
+          return Promise.resolve(ok(absent<readonly PackageTarget[]>()))
+        const packages: PackageTarget[] = []
+        for (const row of rows) {
+          const packageName = row.package_name
+          const revision = row.revision
+          const directory = row.directory
+          const pluginType = row.plugin_type
+          const icon = row.icon
+          const prefix = row.prefix
+          if (typeof packageName !== 'string' || typeof revision !== 'string' || typeof directory !== 'string' || typeof pluginType !== 'string' || typeof icon !== 'string' || typeof prefix !== 'string')
+            return Promise.resolve(failure(storageFailure('read-replication-snapshot', 'stored replication row has unexpected column types')))
+          if (!DEFINITION_DIRECTORIES.includes(directory as PluginDefinition['directory']))
+            return Promise.resolve(failure(storageFailure('read-replication-snapshot', `stored directory "${directory}" is not a known plugin directory`)))
+          if (!DEFINITION_TYPES.includes(pluginType as PluginDefinition['type']))
+            return Promise.resolve(failure(storageFailure('read-replication-snapshot', `stored plugin type "${pluginType}" is not a known plugin type`)))
+          packages.push({
+            packageName,
+            revision,
+            definition: {
+              directory: directory as PluginDefinition['directory'],
+              packageNamePrefix: prefix,
+              type: pluginType as PluginDefinition['type'],
+              icon,
+            },
+          })
+        }
+        return Promise.resolve(ok(present(packages)))
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return Promise.resolve(failure(storageFailure('read-replication-snapshot', errorMessage(error))))
+        return Promise.resolve(failure(storageFailure('read-replication-snapshot', 'database read failed')))
+      }
+    },
+
+    readTaskSummaries(runId: string): Promise<Result<readonly StoredTaskSummary[], RequestFailure>> {
+      try {
+        const rows = database
+          .prepare('SELECT source, task_key, status, detail_json FROM sync_tasks WHERE run_id = ?')
+          .all(runId) as Record<string, object>[]
+        const summaries: StoredTaskSummary[] = []
+        for (const row of rows) {
+          const source = row.source
+          const taskKey = row.task_key
+          const status = row.status
+          const detailJson = row.detail_json
+          if (typeof source !== 'string' || typeof taskKey !== 'string' || typeof status !== 'string' || typeof detailJson !== 'string')
+            return Promise.resolve(failure(storageFailure('read-task-summaries', 'stored task row has unexpected column types')))
+          const detail = decodeJson(storedTaskSummarySchema, JSON.stringify({
+            source,
+            taskKey,
+            status,
+            detail: JSON.parse(detailJson),
+          }), 'read-task-summaries')
+          if (!detail.ok)
+            return Promise.resolve(failure(detail.error))
+          summaries.push({
+            source: detail.value.source,
+            taskKey: detail.value.taskKey,
+            status: detail.value.status,
+          })
+        }
+        return Promise.resolve(ok(summaries))
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return Promise.resolve(failure(storageFailure('read-task-summaries', errorMessage(error))))
+        return Promise.resolve(failure(storageFailure('read-task-summaries', 'database read failed')))
+      }
+    },
+
+    findResumableRun(): Promise<Result<Presence<SyncRun>, RequestFailure>> {
+      const found = readSingleJson(
+        syncRunSchema,
+        'SELECT run_json AS payload FROM sync_runs WHERE status = \'running\' ORDER BY started_at DESC LIMIT 1',
+        [],
+        'find-resumable-run',
+      )
+      return Promise.resolve(found)
+    },
+
+    async createRun(run: SyncRun): Promise<Result<SyncRun, RequestFailure>> {
+      try {
+        withTransaction(() => {
+          database
+            .prepare('INSERT INTO sync_runs (run_id, status, started_at, run_json) VALUES (?, ?, ?, ?)')
+            .run(run.runId, run.status, run.startedAt, JSON.stringify(run))
+        })
+        return ok(run)
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('create-run', errorMessage(error)))
+        return failure(storageFailure('create-run', 'database write failed'))
+      }
+    },
+
+    async updateRun(run: SyncRun): Promise<Result<SyncRun, RequestFailure>> {
+      try {
+        withTransaction(() => {
+          database
+            .prepare('INSERT INTO sync_runs (run_id, status, started_at, run_json) VALUES (?, ?, ?, ?) ON CONFLICT(run_id) DO UPDATE SET status = excluded.status, run_json = excluded.run_json')
+            .run(run.runId, run.status, run.startedAt, JSON.stringify(run))
+        })
+        return ok(run)
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('update-run', errorMessage(error)))
+        return failure(storageFailure('update-run', 'database write failed'))
+      }
+    },
+
+    async saveReplicationSnapshot(runId: string, snapshot: ReplicationSnapshot): Promise<Result<StoredEntityCount, RequestFailure>> {
+      try {
+        const count = withTransaction(() => {
+          database.prepare('DELETE FROM replication_packages WHERE run_id = ?').run(runId)
+          const statement = database.prepare('INSERT INTO replication_packages (run_id, package_name, revision, directory, plugin_type, icon, prefix) VALUES (?, ?, ?, ?, ?, ?, ?)')
+          let written = 0
+          for (const target of snapshot.packages) {
+            statement.run(
+              runId,
+              target.packageName,
+              target.revision,
+              target.definition.directory,
+              target.definition.type,
+              target.definition.icon,
+              target.definition.packageNamePrefix,
+            )
+            written += 1
+          }
+          return written
+        })
+        if (count !== snapshot.packages.length) {
+          return failure(storageFailure('save-replication-snapshot', `written rows (${count}) do not match input count (${snapshot.packages.length})`))
+        }
+        return ok({ count })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('save-replication-snapshot', errorMessage(error)))
+        return failure(storageFailure('save-replication-snapshot', 'database write failed'))
+      }
+    },
+
+    async savePackageMetadata(runId: string, outcomes: readonly PackageMetadataOutcome[]): Promise<Result<StoredEntityCount, RequestFailure>> {
+      try {
+        const count = withTransaction(() => {
+          const cacheStatement = database.prepare('INSERT INTO package_metadata_cache (package_name, cache_json) VALUES (?, ?) ON CONFLICT(package_name) DO UPDATE SET cache_json = excluded.cache_json')
+          const taskStatement = database.prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, \'npm-registry\', ?, \'success\', ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
+          let written = 0
+          for (const outcome of outcomes) {
+            cacheStatement.run(outcome.cache.packageName, JSON.stringify(outcome.cache))
+            taskStatement.run(runId, outcome.record.target.packageName, outcome.attempts, JSON.stringify({
+              completedAt: options.nowIso(),
+              responseStatus: outcome.record.validation === 'response-200' ? 200 : 304,
+            }))
+            written += 1
+          }
+          return written
+        })
+        if (count !== outcomes.length) {
+          return failure(storageFailure('save-package-metadata', `written rows (${count}) do not match input count (${outcomes.length})`))
+        }
+        return ok({ count })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('save-package-metadata', errorMessage(error)))
+        return failure(storageFailure('save-package-metadata', 'database write failed'))
+      }
+    },
+
+    async saveDownloads(runId: string, records: readonly PackageDownloads[]): Promise<Result<StoredEntityCount, RequestFailure>> {
+      try {
+        const count = withTransaction(() => {
+          const statement = database.prepare('INSERT INTO download_points_working (run_id, period_kind, package_name, downloads, start_date, end_date) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, period_kind, package_name) DO UPDATE SET downloads = excluded.downloads, start_date = excluded.start_date, end_date = excluded.end_date')
+          let written = 0
+          for (const record of records) {
+            statement.run(runId, 'daily', record.daily.packageName, record.daily.downloads, record.daily.start, record.daily.end)
+            statement.run(runId, 'monthly', record.monthly.packageName, record.monthly.downloads, record.monthly.start, record.monthly.end)
+            written += 1
+          }
+          return written
+        })
+        if (count !== records.length) {
+          return failure(storageFailure('save-downloads', `written rows (${count}) do not match input count (${records.length})`))
+        }
+        return ok({ count })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('save-downloads', errorMessage(error)))
+        return failure(storageFailure('save-downloads', 'database write failed'))
+      }
+    },
+
+    async saveGitHubRepositories(runId: string, outcomes: readonly GitHubRepositoryOutcome[]): Promise<Result<StoredEntityCount, RequestFailure>> {
+      try {
+        const count = withTransaction(() => {
+          const cacheStatement = database.prepare('INSERT INTO github_repository_cache (full_name, cache_json) VALUES (?, ?) ON CONFLICT(full_name) DO UPDATE SET cache_json = excluded.cache_json')
+          const taskStatement = database.prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, \'github\', ?, \'success\', ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
+          let written = 0
+          for (const outcome of outcomes) {
+            if (outcome.nextCache.state === 'present')
+              cacheStatement.run(outcome.nextCache.value.fullName.toLowerCase(), JSON.stringify(outcome.nextCache.value))
+            taskStatement.run(runId, outcome.record.data.fullName.toLowerCase(), outcome.attempts, JSON.stringify({
+              completedAt: options.nowIso(),
+              responseStatus: outcome.record.validation === 'response-200' ? 200 : 304,
+            }))
+            written += 1
+          }
+          return written
+        })
+        if (count !== outcomes.length) {
+          return failure(storageFailure('save-github-repositories', `written rows (${count}) do not match input count (${outcomes.length})`))
+        }
+        return ok({ count })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('save-github-repositories', errorMessage(error)))
+        return failure(storageFailure('save-github-repositories', 'database write failed'))
+      }
+    },
+
+    async recordTaskSuccess(runId: string, source: ApiHost, taskKey: string, attempt: number, responseStatus: number): Promise<Result<StoredTaskSummary, RequestFailure>> {
+      try {
+        const detail = { completedAt: options.nowIso(), responseStatus }
+        withTransaction(() => {
+          database
+            .prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
+            .run(runId, source, taskKey, 'success', attempt, JSON.stringify(detail))
+        })
+        return ok({ source, taskKey, status: 'success' })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('record-task-success', errorMessage(error)))
+        return failure(storageFailure('record-task-success', 'database write failed'))
+      }
+    },
+
+    async recordTaskFailure(runId: string, source: ApiHost, taskKey: string, attempt: number, failureInfo: RequestFailure): Promise<Result<StoredTaskSummary, RequestFailure>> {
+      try {
+        const detail = { failedAt: options.nowIso(), failure: failureInfo }
+        withTransaction(() => {
+          database
+            .prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
+            .run(runId, source, taskKey, 'failed', attempt, JSON.stringify(detail))
+        })
+        return ok({ source, taskKey, status: 'failed' })
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('record-task-failure', errorMessage(error)))
+        return failure(storageFailure('record-task-failure', 'database write failed'))
+      }
+    },
+
+    async savePublishedSnapshot(published: PublishedSnapshot, snapshot: CompletePluginSnapshot): Promise<Result<PublishedSnapshot, RequestFailure>> {
+      try {
+        withTransaction(() => {
+          database
+            .prepare('INSERT INTO published_snapshots (snapshot_id, snapshot_json) VALUES (?, ?) ON CONFLICT(snapshot_id) DO UPDATE SET snapshot_json = excluded.snapshot_json')
+            .run(published.snapshotId, JSON.stringify({
+              published,
+              summary: {
+                snapshotId: snapshot.snapshotId,
+                startedAt: snapshot.startedAt,
+                completedAt: snapshot.completedAt,
+                entryCount: snapshot.entries.length,
+                replicationStartSequence: snapshot.replicationStartSequence,
+                replicationEndSequence: snapshot.replicationEndSequence,
+                dailyPeriod: snapshot.dailyPeriod,
+                monthlyPeriod: snapshot.monthlyPeriod,
+              },
+            }))
+        })
+        return ok(published)
+      }
+      catch (error) {
+        if (error instanceof Error)
+          return failure(storageFailure('save-published-snapshot', errorMessage(error)))
+        return failure(storageFailure('save-published-snapshot', 'database write failed'))
+      }
+    },
+
+    close(): void {
+      database.close()
+    },
+  }
+
+  return store
+}

--- a/packages/generate/src/generate-plugin/state-store.ts
+++ b/packages/generate/src/generate-plugin/state-store.ts
@@ -1,87 +1,34 @@
-// 持久化状态：node:sqlite 单库存储 run、task、缓存实体与快照记录。
-// 复杂值以 JSON 列存储并通过 schema 往返校验；简单标量使用普通列。
-// 每个成功请求在事务内同时写业务实体、校验器与 task 成功状态。
+// 跨 Run 缓存存储：两个 JSON 文件分别保存 metadata 校验器与 GitHub 校验器。
+// 缓存是"跨天"状态而非 run 内状态：有了它，每日全量检查的多数响应退化为 304，
+// GitHub 认证下 304 不消耗 rate limit 配额。run 内任务状态不持久化，崩溃即重跑。
+// 写入策略：内存 Map 即时更新，累计 FLUSH_THRESHOLD 条或调用 flush() 时原子落盘。
 
 import type { ZodType } from 'zod'
-import type { ApiHost, CompletePluginSnapshot, DownloadPoint, GitHubRepositoryCache, GitHubRepositoryOutcome, PackageDownloads, PackageMetadataCache, PackageMetadataOutcome, PackageTarget, PluginDefinition, Presence, PublishedSnapshot, ReplicationSnapshot, RequestFailure, Result, StateStore, StoredEntityCount, StoredTaskSummary, SyncRun } from './contracts'
-import { mkdirSync } from 'node:fs'
+import type { CacheStore, GitHubRepositoryCache, PackageMetadataCache, RequestFailure, Result } from './contracts'
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
-import { DatabaseSync } from 'node:sqlite'
+import { z } from 'zod'
 import {
-  absent,
 
   failure,
 
   ok,
 
-  present,
-
 } from './contracts'
-import {
-  githubRepositoryCacheSchema,
-  packageMetadataCacheSchema,
-  storedTaskSummarySchema,
-  syncRunSchema,
-} from './schemas'
+import { githubRepositoryCacheSchema, packageMetadataCacheSchema } from './schemas'
+import { hasNodeErrorCode } from './utils'
 
-export interface StateStoreOptions {
-  databasePath: string
-  nowIso: () => string
+export interface JsonCacheStoreOptions {
+  metadataCachePath: string
+  githubCachePath: string
 }
 
-const DATABASE_SCHEMA = `
-CREATE TABLE IF NOT EXISTS sync_runs (
-  run_id TEXT PRIMARY KEY,
-  status TEXT,
-  started_at TEXT,
-  run_json TEXT
-);
-CREATE TABLE IF NOT EXISTS replication_packages (
-  run_id TEXT,
-  package_name TEXT,
-  revision TEXT,
-  directory TEXT,
-  plugin_type TEXT,
-  icon TEXT,
-  prefix TEXT,
-  PRIMARY KEY (run_id, package_name)
-);
-CREATE TABLE IF NOT EXISTS package_metadata_cache (
-  package_name TEXT PRIMARY KEY,
-  cache_json TEXT
-);
-CREATE TABLE IF NOT EXISTS download_points_working (
-  run_id TEXT,
-  period_kind TEXT,
-  package_name TEXT,
-  downloads INTEGER,
-  start_date TEXT,
-  end_date TEXT,
-  PRIMARY KEY (run_id, period_kind, package_name)
-);
-CREATE TABLE IF NOT EXISTS github_repository_cache (
-  full_name TEXT PRIMARY KEY,
-  cache_json TEXT
-);
-CREATE TABLE IF NOT EXISTS sync_tasks (
-  run_id TEXT,
-  source TEXT,
-  task_key TEXT,
-  status TEXT,
-  attempt INTEGER,
-  detail_json TEXT,
-  PRIMARY KEY (run_id, source, task_key)
-);
-CREATE TABLE IF NOT EXISTS published_snapshots (
-  snapshot_id TEXT PRIMARY KEY,
-  snapshot_json TEXT
-);
-`
+const FLUSH_THRESHOLD = 500
 
-const DEFINITION_DIRECTORIES: readonly PluginDefinition['directory'][] = ['vite', 'rollup', 'rolldown', 'unplugin']
-const DEFINITION_TYPES: readonly PluginDefinition['type'][] = ['vite-plugin', 'rollup-plugin', 'rolldown-plugin', 'unplugin']
+const metadataCacheFileSchema: ZodType<Record<string, PackageMetadataCache>> = z.record(z.string(), packageMetadataCacheSchema)
+const githubCacheFileSchema: ZodType<Record<string, GitHubRepositoryCache>> = z.record(z.string(), githubRepositoryCacheSchema)
 
-function storageFailure(operation: string, message: string): RequestFailure {
+function cacheFailure(operation: string, message: string): RequestFailure {
   return { kind: 'storage', operation, message }
 }
 
@@ -89,439 +36,107 @@ function errorMessage(error: Error): string {
   return error.message
 }
 
-export function openStateStore(options: StateStoreOptions): StateStore {
-  mkdirSync(dirname(options.databasePath), { recursive: true })
-  const database = new DatabaseSync(options.databasePath)
-  database.exec('PRAGMA journal_mode = WAL')
-  database.exec('PRAGMA synchronous = NORMAL')
-  database.exec(DATABASE_SCHEMA)
-
-  function withTransaction<T>(operation: () => T): T {
-    database.exec('BEGIN')
+export function openJsonCacheStore(options: JsonCacheStoreOptions): Result<CacheStore, RequestFailure> {
+  function readCacheFile<T>(path: string, schema: ZodType<Record<string, T>>, operation: string): Result<Map<string, T>, RequestFailure> {
+    let raw: string
     try {
-      const value = operation()
-      database.exec('COMMIT')
-      return value
+      raw = readFileSync(path, 'utf8')
     }
     catch (error) {
-      database.exec('ROLLBACK')
-      throw error
+      if (error instanceof Error && hasNodeErrorCode(error, 'ENOENT'))
+        return ok(new Map())
+      if (error instanceof Error)
+        return failure(cacheFailure(operation, errorMessage(error)))
+      return failure(cacheFailure(operation, 'cache file read failed'))
     }
-  }
-
-  function decodeJson<T>(schema: ZodType<T>, raw: string, operation: string): Result<T, RequestFailure> {
-    if (typeof raw !== 'string')
-      return failure(storageFailure(operation, 'stored payload is not a json string'))
     let parsedValue: object
     try {
       parsedValue = JSON.parse(raw)
     }
     catch (error) {
       if (error instanceof Error)
-        return failure(storageFailure(operation, `stored json is not parseable: ${errorMessage(error)}`))
-      return failure(storageFailure(operation, 'stored json is not parseable'))
+        return failure(cacheFailure(operation, `cache file is not parseable: ${errorMessage(error)}`))
+      return failure(cacheFailure(operation, 'cache file is not parseable'))
     }
     const validated = schema.safeParse(parsedValue)
     if (!validated.success) {
-      return failure(storageFailure(operation, `stored json failed schema validation: ${validated.error.issues[0]?.message ?? ''}`))
+      return failure(cacheFailure(operation, `cache file failed schema validation: ${validated.error.issues[0]?.message ?? ''}`))
     }
-    return ok(validated.data)
+    return ok(new Map(Object.entries(validated.data)))
   }
 
-  function readTextRows(sql: string, parameters: readonly string[], operation: string): Result<readonly string[], RequestFailure> {
+  const metadataCaches = readCacheFile(options.metadataCachePath, metadataCacheFileSchema, 'read-metadata-cache-file')
+  if (!metadataCaches.ok)
+    return metadataCaches
+  const githubCaches = readCacheFile(options.githubCachePath, githubCacheFileSchema, 'read-github-cache-file')
+  if (!githubCaches.ok)
+    return githubCaches
+  const metadataEntries = metadataCaches.value
+  const githubEntries = githubCaches.value
+
+  let metadataDirty = false
+  let githubDirty = false
+
+  function writeCacheFile(path: string, entries: Map<string, PackageMetadataCache | GitHubRepositoryCache>, operation: string): Result<boolean, RequestFailure> {
     try {
-      const rows = database.prepare(sql).all(...parameters)
-      const payloads: string[] = []
-      for (const row of rows) {
-        const payload = (row as Record<string, object>).payload
-        if (typeof payload !== 'string')
-          return failure(storageFailure(operation, 'stored row payload is not a string'))
-        payloads.push(payload)
-      }
-      return ok(payloads)
+      mkdirSync(dirname(path), { recursive: true })
+      const temporaryPath = `${path}.tmp`
+      writeFileSync(temporaryPath, JSON.stringify(Object.fromEntries(entries)))
+      renameSync(temporaryPath, path)
+      return ok(true)
     }
     catch (error) {
       if (error instanceof Error)
-        return failure(storageFailure(operation, errorMessage(error)))
-      return failure(storageFailure(operation, 'database read failed'))
+        return failure(cacheFailure(operation, errorMessage(error)))
+      return failure(cacheFailure(operation, 'cache file write failed'))
     }
   }
 
-  function readAllJson<T>(schema: ZodType<T>, sql: string, operation: string): Result<readonly T[], RequestFailure> {
-    const payloads = readTextRows(sql, [], operation)
-    if (!payloads.ok)
-      return payloads
-    const decoded: T[] = []
-    for (const payload of payloads.value) {
-      const entry = decodeJson(schema, payload, operation)
-      if (!entry.ok)
-        return entry
-      decoded.push(entry.value)
+  function flush(): Result<boolean, RequestFailure> {
+    if (metadataDirty) {
+      const written = writeCacheFile(options.metadataCachePath, metadataEntries, 'flush-metadata-cache')
+      if (!written.ok)
+        return written
+      metadataDirty = false
     }
-    return ok(decoded)
+    if (githubDirty) {
+      const written = writeCacheFile(options.githubCachePath, githubEntries, 'flush-github-cache')
+      if (!written.ok)
+        return written
+      githubDirty = false
+    }
+    return ok(true)
   }
 
-  function readSingleJson<T>(schema: ZodType<T>, sql: string, parameters: readonly string[], operation: string): Result<Presence<T>, RequestFailure> {
-    try {
-      const row = database.prepare(sql).get(...parameters) as Record<string, object> | void
-      if (typeof row !== 'object')
-        return ok(absent<T>())
-      const payload = row.payload
-      if (typeof payload !== 'string')
-        return failure(storageFailure(operation, 'stored row payload is not a string'))
-      const decoded = decodeJson(schema, payload, operation)
-      if (!decoded.ok)
-        return failure(decoded.error)
-      return ok(present(decoded.value))
-    }
-    catch (error) {
-      if (error instanceof Error)
-        return failure(storageFailure(operation, errorMessage(error)))
-      return failure(storageFailure(operation, 'database read failed'))
-    }
+  const store: CacheStore = {
+    readMetadataCaches: () => ok([...metadataEntries.values()]),
+    readGitHubCaches: () => ok([...githubEntries.values()]),
+
+    saveMetadataCache: (cache: PackageMetadataCache): Result<boolean, RequestFailure> => {
+      metadataEntries.set(cache.packageName, cache)
+      metadataDirty = true
+      if (metadataEntries.size % FLUSH_THRESHOLD === 0) {
+        const written = flush()
+        if (!written.ok)
+          return written
+      }
+      return ok(true)
+    },
+
+    saveGitHubCache: (cache: GitHubRepositoryCache): Result<boolean, RequestFailure> => {
+      githubEntries.set(cache.fullName.toLowerCase(), cache)
+      githubDirty = true
+      if (githubEntries.size % FLUSH_THRESHOLD === 0) {
+        const written = flush()
+        if (!written.ok)
+          return written
+      }
+      return ok(true)
+    },
+
+    flush,
+    close: () => {},
   }
 
-  const store: StateStore = {
-    readPackageMetadataCaches(): Promise<Result<readonly PackageMetadataCache[], RequestFailure>> {
-      return Promise.resolve(readAllJson(
-        packageMetadataCacheSchema,
-        'SELECT cache_json AS payload FROM package_metadata_cache ORDER BY package_name',
-        'read-package-metadata-caches',
-      ))
-    },
-
-    readGitHubCaches(): Promise<Result<readonly GitHubRepositoryCache[], RequestFailure>> {
-      return Promise.resolve(readAllJson(
-        githubRepositoryCacheSchema,
-        'SELECT cache_json AS payload FROM github_repository_cache ORDER BY full_name',
-        'read-github-caches',
-      ))
-    },
-
-    readWorkingDownloadPoints(runId: string): Promise<Result<readonly DownloadPoint[], RequestFailure>> {
-      try {
-        const rows = database
-          .prepare('SELECT package_name, downloads, start_date, end_date FROM download_points_working WHERE run_id = ?')
-          .all(runId) as Record<string, object>[]
-        const points: DownloadPoint[] = []
-        for (const row of rows) {
-          const packageName = row.package_name
-          const downloads = row.downloads
-          const startDate = row.start_date
-          const endDate = row.end_date
-          if (typeof packageName !== 'string' || typeof downloads !== 'number' || typeof startDate !== 'string' || typeof endDate !== 'string')
-            return Promise.resolve(failure(storageFailure('read-working-download-points', 'stored download point row has unexpected column types')))
-          if (!Number.isSafeInteger(downloads) || downloads < 0)
-            return Promise.resolve(failure(storageFailure('read-working-download-points', `stored download count for "${packageName}" is not a non-negative integer`)))
-          points.push({ packageName, downloads, start: startDate, end: endDate })
-        }
-        return Promise.resolve(ok(points))
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return Promise.resolve(failure(storageFailure('read-working-download-points', errorMessage(error))))
-        return Promise.resolve(failure(storageFailure('read-working-download-points', 'database read failed')))
-      }
-    },
-
-    readReplicationSnapshot(runId: string): Promise<Result<Presence<readonly PackageTarget[]>, RequestFailure>> {
-      try {
-        const rows = database
-          .prepare('SELECT package_name, revision, directory, plugin_type, icon, prefix FROM replication_packages WHERE run_id = ? ORDER BY package_name')
-          .all(runId) as Record<string, object>[]
-        if (rows.length === 0)
-          return Promise.resolve(ok(absent<readonly PackageTarget[]>()))
-        const packages: PackageTarget[] = []
-        for (const row of rows) {
-          const packageName = row.package_name
-          const revision = row.revision
-          const directory = row.directory
-          const pluginType = row.plugin_type
-          const icon = row.icon
-          const prefix = row.prefix
-          if (typeof packageName !== 'string' || typeof revision !== 'string' || typeof directory !== 'string' || typeof pluginType !== 'string' || typeof icon !== 'string' || typeof prefix !== 'string')
-            return Promise.resolve(failure(storageFailure('read-replication-snapshot', 'stored replication row has unexpected column types')))
-          if (!DEFINITION_DIRECTORIES.includes(directory as PluginDefinition['directory']))
-            return Promise.resolve(failure(storageFailure('read-replication-snapshot', `stored directory "${directory}" is not a known plugin directory`)))
-          if (!DEFINITION_TYPES.includes(pluginType as PluginDefinition['type']))
-            return Promise.resolve(failure(storageFailure('read-replication-snapshot', `stored plugin type "${pluginType}" is not a known plugin type`)))
-          packages.push({
-            packageName,
-            revision,
-            definition: {
-              directory: directory as PluginDefinition['directory'],
-              packageNamePrefix: prefix,
-              type: pluginType as PluginDefinition['type'],
-              icon,
-            },
-          })
-        }
-        return Promise.resolve(ok(present(packages)))
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return Promise.resolve(failure(storageFailure('read-replication-snapshot', errorMessage(error))))
-        return Promise.resolve(failure(storageFailure('read-replication-snapshot', 'database read failed')))
-      }
-    },
-
-    readTaskSummaries(runId: string): Promise<Result<readonly StoredTaskSummary[], RequestFailure>> {
-      try {
-        const rows = database
-          .prepare('SELECT source, task_key, status, detail_json FROM sync_tasks WHERE run_id = ?')
-          .all(runId) as Record<string, object>[]
-        const summaries: StoredTaskSummary[] = []
-        for (const row of rows) {
-          const source = row.source
-          const taskKey = row.task_key
-          const status = row.status
-          const detailJson = row.detail_json
-          if (typeof source !== 'string' || typeof taskKey !== 'string' || typeof status !== 'string' || typeof detailJson !== 'string')
-            return Promise.resolve(failure(storageFailure('read-task-summaries', 'stored task row has unexpected column types')))
-          const detail = decodeJson(storedTaskSummarySchema, JSON.stringify({
-            source,
-            taskKey,
-            status,
-            detail: JSON.parse(detailJson),
-          }), 'read-task-summaries')
-          if (!detail.ok)
-            return Promise.resolve(failure(detail.error))
-          summaries.push({
-            source: detail.value.source,
-            taskKey: detail.value.taskKey,
-            status: detail.value.status,
-          })
-        }
-        return Promise.resolve(ok(summaries))
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return Promise.resolve(failure(storageFailure('read-task-summaries', errorMessage(error))))
-        return Promise.resolve(failure(storageFailure('read-task-summaries', 'database read failed')))
-      }
-    },
-
-    findResumableRun(): Promise<Result<Presence<SyncRun>, RequestFailure>> {
-      const found = readSingleJson(
-        syncRunSchema,
-        'SELECT run_json AS payload FROM sync_runs WHERE status = \'running\' ORDER BY started_at DESC LIMIT 1',
-        [],
-        'find-resumable-run',
-      )
-      return Promise.resolve(found)
-    },
-
-    async createRun(run: SyncRun): Promise<Result<SyncRun, RequestFailure>> {
-      try {
-        withTransaction(() => {
-          database
-            .prepare('INSERT INTO sync_runs (run_id, status, started_at, run_json) VALUES (?, ?, ?, ?)')
-            .run(run.runId, run.status, run.startedAt, JSON.stringify(run))
-        })
-        return ok(run)
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('create-run', errorMessage(error)))
-        return failure(storageFailure('create-run', 'database write failed'))
-      }
-    },
-
-    async updateRun(run: SyncRun): Promise<Result<SyncRun, RequestFailure>> {
-      try {
-        withTransaction(() => {
-          database
-            .prepare('INSERT INTO sync_runs (run_id, status, started_at, run_json) VALUES (?, ?, ?, ?) ON CONFLICT(run_id) DO UPDATE SET status = excluded.status, run_json = excluded.run_json')
-            .run(run.runId, run.status, run.startedAt, JSON.stringify(run))
-        })
-        return ok(run)
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('update-run', errorMessage(error)))
-        return failure(storageFailure('update-run', 'database write failed'))
-      }
-    },
-
-    async saveReplicationSnapshot(runId: string, snapshot: ReplicationSnapshot): Promise<Result<StoredEntityCount, RequestFailure>> {
-      try {
-        const count = withTransaction(() => {
-          database.prepare('DELETE FROM replication_packages WHERE run_id = ?').run(runId)
-          const statement = database.prepare('INSERT INTO replication_packages (run_id, package_name, revision, directory, plugin_type, icon, prefix) VALUES (?, ?, ?, ?, ?, ?, ?)')
-          let written = 0
-          for (const target of snapshot.packages) {
-            statement.run(
-              runId,
-              target.packageName,
-              target.revision,
-              target.definition.directory,
-              target.definition.type,
-              target.definition.icon,
-              target.definition.packageNamePrefix,
-            )
-            written += 1
-          }
-          return written
-        })
-        if (count !== snapshot.packages.length) {
-          return failure(storageFailure('save-replication-snapshot', `written rows (${count}) do not match input count (${snapshot.packages.length})`))
-        }
-        return ok({ count })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('save-replication-snapshot', errorMessage(error)))
-        return failure(storageFailure('save-replication-snapshot', 'database write failed'))
-      }
-    },
-
-    async savePackageMetadata(runId: string, outcomes: readonly PackageMetadataOutcome[]): Promise<Result<StoredEntityCount, RequestFailure>> {
-      try {
-        const count = withTransaction(() => {
-          const cacheStatement = database.prepare('INSERT INTO package_metadata_cache (package_name, cache_json) VALUES (?, ?) ON CONFLICT(package_name) DO UPDATE SET cache_json = excluded.cache_json')
-          const taskStatement = database.prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, \'npm-registry\', ?, \'success\', ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
-          let written = 0
-          for (const outcome of outcomes) {
-            cacheStatement.run(outcome.cache.packageName, JSON.stringify(outcome.cache))
-            taskStatement.run(runId, outcome.record.target.packageName, outcome.attempts, JSON.stringify({
-              completedAt: options.nowIso(),
-              responseStatus: outcome.record.validation === 'response-200' ? 200 : 304,
-            }))
-            written += 1
-          }
-          return written
-        })
-        if (count !== outcomes.length) {
-          return failure(storageFailure('save-package-metadata', `written rows (${count}) do not match input count (${outcomes.length})`))
-        }
-        return ok({ count })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('save-package-metadata', errorMessage(error)))
-        return failure(storageFailure('save-package-metadata', 'database write failed'))
-      }
-    },
-
-    async saveDownloads(runId: string, records: readonly PackageDownloads[]): Promise<Result<StoredEntityCount, RequestFailure>> {
-      try {
-        const count = withTransaction(() => {
-          const statement = database.prepare('INSERT INTO download_points_working (run_id, period_kind, package_name, downloads, start_date, end_date) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, period_kind, package_name) DO UPDATE SET downloads = excluded.downloads, start_date = excluded.start_date, end_date = excluded.end_date')
-          let written = 0
-          for (const record of records) {
-            statement.run(runId, 'daily', record.daily.packageName, record.daily.downloads, record.daily.start, record.daily.end)
-            statement.run(runId, 'monthly', record.monthly.packageName, record.monthly.downloads, record.monthly.start, record.monthly.end)
-            written += 1
-          }
-          return written
-        })
-        if (count !== records.length) {
-          return failure(storageFailure('save-downloads', `written rows (${count}) do not match input count (${records.length})`))
-        }
-        return ok({ count })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('save-downloads', errorMessage(error)))
-        return failure(storageFailure('save-downloads', 'database write failed'))
-      }
-    },
-
-    async saveGitHubRepositories(runId: string, outcomes: readonly GitHubRepositoryOutcome[]): Promise<Result<StoredEntityCount, RequestFailure>> {
-      try {
-        const count = withTransaction(() => {
-          const cacheStatement = database.prepare('INSERT INTO github_repository_cache (full_name, cache_json) VALUES (?, ?) ON CONFLICT(full_name) DO UPDATE SET cache_json = excluded.cache_json')
-          const taskStatement = database.prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, \'github\', ?, \'success\', ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
-          let written = 0
-          for (const outcome of outcomes) {
-            if (outcome.nextCache.state === 'present')
-              cacheStatement.run(outcome.nextCache.value.fullName.toLowerCase(), JSON.stringify(outcome.nextCache.value))
-            taskStatement.run(runId, outcome.record.data.fullName.toLowerCase(), outcome.attempts, JSON.stringify({
-              completedAt: options.nowIso(),
-              responseStatus: outcome.record.validation === 'response-200' ? 200 : 304,
-            }))
-            written += 1
-          }
-          return written
-        })
-        if (count !== outcomes.length) {
-          return failure(storageFailure('save-github-repositories', `written rows (${count}) do not match input count (${outcomes.length})`))
-        }
-        return ok({ count })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('save-github-repositories', errorMessage(error)))
-        return failure(storageFailure('save-github-repositories', 'database write failed'))
-      }
-    },
-
-    async recordTaskSuccess(runId: string, source: ApiHost, taskKey: string, attempt: number, responseStatus: number): Promise<Result<StoredTaskSummary, RequestFailure>> {
-      try {
-        const detail = { completedAt: options.nowIso(), responseStatus }
-        withTransaction(() => {
-          database
-            .prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
-            .run(runId, source, taskKey, 'success', attempt, JSON.stringify(detail))
-        })
-        return ok({ source, taskKey, status: 'success' })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('record-task-success', errorMessage(error)))
-        return failure(storageFailure('record-task-success', 'database write failed'))
-      }
-    },
-
-    async recordTaskFailure(runId: string, source: ApiHost, taskKey: string, attempt: number, failureInfo: RequestFailure): Promise<Result<StoredTaskSummary, RequestFailure>> {
-      try {
-        const detail = { failedAt: options.nowIso(), failure: failureInfo }
-        withTransaction(() => {
-          database
-            .prepare('INSERT INTO sync_tasks (run_id, source, task_key, status, attempt, detail_json) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(run_id, source, task_key) DO UPDATE SET status = excluded.status, attempt = excluded.attempt, detail_json = excluded.detail_json')
-            .run(runId, source, taskKey, 'failed', attempt, JSON.stringify(detail))
-        })
-        return ok({ source, taskKey, status: 'failed' })
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('record-task-failure', errorMessage(error)))
-        return failure(storageFailure('record-task-failure', 'database write failed'))
-      }
-    },
-
-    async savePublishedSnapshot(published: PublishedSnapshot, snapshot: CompletePluginSnapshot): Promise<Result<PublishedSnapshot, RequestFailure>> {
-      try {
-        withTransaction(() => {
-          database
-            .prepare('INSERT INTO published_snapshots (snapshot_id, snapshot_json) VALUES (?, ?) ON CONFLICT(snapshot_id) DO UPDATE SET snapshot_json = excluded.snapshot_json')
-            .run(published.snapshotId, JSON.stringify({
-              published,
-              summary: {
-                snapshotId: snapshot.snapshotId,
-                startedAt: snapshot.startedAt,
-                completedAt: snapshot.completedAt,
-                entryCount: snapshot.entries.length,
-                replicationStartSequence: snapshot.replicationStartSequence,
-                replicationEndSequence: snapshot.replicationEndSequence,
-                dailyPeriod: snapshot.dailyPeriod,
-                monthlyPeriod: snapshot.monthlyPeriod,
-              },
-            }))
-        })
-        return ok(published)
-      }
-      catch (error) {
-        if (error instanceof Error)
-          return failure(storageFailure('save-published-snapshot', errorMessage(error)))
-        return failure(storageFailure('save-published-snapshot', 'database write failed'))
-      }
-    },
-
-    close(): void {
-      database.close()
-    },
-  }
-
-  return store
+  return ok(store)
 }

--- a/packages/generate/src/generate-plugin/utils.ts
+++ b/packages/generate/src/generate-plugin/utils.ts
@@ -1,0 +1,19 @@
+// 通用工具：睡眠、哈希与响应哈希校验。
+
+import { createHash } from 'node:crypto'
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export function sha256Hex(input: string): string {
+  return createHash('sha256').update(input).digest('hex')
+}
+
+export function isValidResponseHash(value: string): boolean {
+  return /^[0-9a-f]{64}$/.test(value)
+}
+
+export function hasNodeErrorCode(error: Error, code: string): boolean {
+  return 'code' in error && error.code === code
+}

--- a/packages/generate/src/scripts/generate-plugin-names.ts
+++ b/packages/generate/src/scripts/generate-plugin-names.ts
@@ -1,0 +1,110 @@
+// @env node
+// 入口脚本：只负责装配和启动每日全量同步。
+// GitHub Token 从仓库根目录 .env 的 GENERATE_TOKEN 读取（认证后 5000 次/小时）。
+
+import type { RequestFailure, Result } from '../generate-plugin/contracts'
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { createSystemClock } from '../generate-plugin/clock'
+import { pluginDefinitions } from '../generate-plugin/definitions'
+import { DEFAULT_HOST_POLICIES, runDailyPluginPipeline } from '../generate-plugin/pipeline'
+import { createSnapshotPublisher } from '../generate-plugin/snapshot-publisher'
+import { openStateStore } from '../generate-plugin/state-store'
+
+const scriptDir = dirname(fileURLToPath(import.meta.url))
+const packageRoot = resolve(scriptDir, '../..')
+const repositoryRoot = resolve(scriptDir, '../../../..')
+
+function readEnvFile(envPath: string): Map<string, string> {
+  const entries = new Map<string, string>()
+  let content: string
+  try {
+    content = readFileSync(envPath, 'utf8')
+  }
+  catch {
+    return entries
+  }
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim()
+    if (line.length === 0 || line.startsWith('#'))
+      continue
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0)
+      continue
+    const key = line.slice(0, separatorIndex).trim()
+    let value = line.slice(separatorIndex + 1).trim()
+    const wrappedInDoubleQuotes = value.startsWith('"') && value.endsWith('"') && value.length >= 2
+    const wrappedInSingleQuotes = value.startsWith('\'') && value.endsWith('\'') && value.length >= 2
+    if (wrappedInDoubleQuotes || wrappedInSingleQuotes)
+      value = value.slice(1, -1)
+    entries.set(key, value)
+  }
+  return entries
+}
+
+function resolveGitHubToken(): Result<string, RequestFailure> {
+  const fromEnvironment = process.env.GENERATE_TOKEN
+  if (typeof fromEnvironment === 'string' && fromEnvironment.length > 0)
+    return { ok: true, value: fromEnvironment }
+  const fromEnvFile = readEnvFile(resolve(repositoryRoot, '.env')).get('GENERATE_TOKEN')
+  if (typeof fromEnvFile === 'string' && fromEnvFile.length > 0)
+    return { ok: true, value: fromEnvFile }
+  return {
+    ok: false,
+    error: {
+      kind: 'invariant',
+      message: 'GENERATE_TOKEN is missing: set it in the repository root .env file or in the process environment',
+    },
+  }
+}
+
+async function main(): Promise<void> {
+  const token = resolveGitHubToken()
+  if (!token.ok) {
+    console.error('daily plugin pipeline cannot start.', JSON.stringify(token.error))
+    process.exitCode = 1
+    return
+  }
+
+  const clock = createSystemClock()
+  const store = openStateStore({
+    databasePath: resolve(packageRoot, '.sync-work/state.sqlite'),
+    nowIso: () => clock.nowIso(),
+  })
+  const publisher = createSnapshotPublisher({ packageRoot, nowIso: () => clock.nowIso() })
+
+  try {
+    const outcome = await runDailyPluginPipeline(
+      {
+        store,
+        clock,
+        replicationPolicy: DEFAULT_HOST_POLICIES.replication,
+        npmRegistryPolicy: DEFAULT_HOST_POLICIES['npm-registry'],
+        npmDownloadsPolicy: DEFAULT_HOST_POLICIES['npm-downloads'],
+        githubPolicy: DEFAULT_HOST_POLICIES.github,
+        githubToken: token.value,
+        publisher,
+      },
+      pluginDefinitions,
+      clock.nowIso(),
+    )
+    if (!outcome.ok) {
+      console.error('daily plugin pipeline failed.', JSON.stringify(outcome.error))
+      process.exitCode = 1
+      return
+    }
+    console.log(`daily plugin pipeline finished: snapshotId=${outcome.value.snapshotId} entries=${outcome.value.entries.length}`)
+  }
+  finally {
+    store.close()
+  }
+}
+
+try {
+  await main()
+}
+catch (error) {
+  console.error('daily plugin pipeline crashed.', error)
+  process.exitCode = 1
+}

--- a/packages/generate/src/scripts/generate-plugin-names.ts
+++ b/packages/generate/src/scripts/generate-plugin-names.ts
@@ -1,6 +1,7 @@
 // @env node
 // 入口脚本：只负责装配和启动每日全量同步。
 // GitHub Token 从仓库根目录 .env 的 GENERATE_TOKEN 读取（认证后 5000 次/小时）。
+// 跨 Run 缓存保存在 .sync-work/ 下的 JSON 文件（已 gitignore，不随仓库上传）。
 
 import type { RequestFailure, Result } from '../generate-plugin/contracts'
 import { readFileSync } from 'node:fs'
@@ -10,7 +11,7 @@ import { createSystemClock } from '../generate-plugin/clock'
 import { pluginDefinitions } from '../generate-plugin/definitions'
 import { DEFAULT_HOST_POLICIES, runDailyPluginPipeline } from '../generate-plugin/pipeline'
 import { createSnapshotPublisher } from '../generate-plugin/snapshot-publisher'
-import { openStateStore } from '../generate-plugin/state-store'
+import { openJsonCacheStore } from '../generate-plugin/state-store'
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const packageRoot = resolve(scriptDir, '../..')
@@ -67,17 +68,24 @@ async function main(): Promise<void> {
     return
   }
 
-  const clock = createSystemClock()
-  const store = openStateStore({
-    databasePath: resolve(packageRoot, '.sync-work/state.sqlite'),
-    nowIso: () => clock.nowIso(),
+  const cacheStoreOutcome = openJsonCacheStore({
+    metadataCachePath: resolve(packageRoot, '.sync-work/metadata-cache.json'),
+    githubCachePath: resolve(packageRoot, '.sync-work/github-cache.json'),
   })
+  if (!cacheStoreOutcome.ok) {
+    console.error('daily plugin pipeline cannot start.', JSON.stringify(cacheStoreOutcome.error))
+    process.exitCode = 1
+    return
+  }
+  const cacheStore = cacheStoreOutcome.value
+
+  const clock = createSystemClock()
   const publisher = createSnapshotPublisher({ packageRoot, nowIso: () => clock.nowIso() })
 
   try {
     const outcome = await runDailyPluginPipeline(
       {
-        store,
+        cacheStore,
         clock,
         replicationPolicy: DEFAULT_HOST_POLICIES.replication,
         npmRegistryPolicy: DEFAULT_HOST_POLICIES['npm-registry'],
@@ -97,7 +105,10 @@ async function main(): Promise<void> {
     console.log(`daily plugin pipeline finished: snapshotId=${outcome.value.snapshotId} entries=${outcome.value.entries.length}`)
   }
   finally {
-    store.close()
+    const flushed = cacheStore.flush()
+    if (!flushed.ok)
+      console.error('cache flush failed on exit.', JSON.stringify(flushed.error))
+    cacheStore.close()
   }
 }
 

--- a/packages/generate/tsconfig.json
+++ b/packages/generate/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["@vuejs-community/tsconfig/base.json"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,27 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
+  packages/generate:
+    devDependencies:
+      '@types/node':
+        specifier: ^26.4.0
+        version: 26.4.0
+      '@vuejs-community/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      p-queue:
+        specifier: ^9.3.3
+        version: 9.3.3
+      tsx:
+        specifier: ^4.23.13
+        version: 4.23.13
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      zod:
+        specifier: ^4.5.4
+        version: 4.5.4
+
   packages/schema:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
### 🤔 This is a ...

- [x] 🆕 New feature
- [ ] 🐞 Bug fix
- [ ] 📝 Site / documentation improvement
- [ ] 📽️ Demo improvement
- [ ] 💄 Component style improvement
- [ ] 🤖 TypeScript definition improvement
- [ ] 📦 Bundle size optimization
- [ ] ⚡️ Performance optimization
- [ ] ⭐️ Feature enhancement
- [ ] 🌐 Internationalization
- [ ] 🛠 Refactoring
- [ ] 🎨 Code style optimization
- [ ] ✅ Test Case
- [ ] 🔀 Branch merge
- [ ] ⏩ Workflow
- [ ] ⌨️ Accessibility improvement
- [ ] ❓ Other (about what?)

### 🔗 Related Issues

None

### 💡 Background and Solution

Plugin data generation previously depended on `npm search`, which is
keyword-based (not prefix-based) and intermittently fails with
`npm search request failed`, so matched packages were incomplete and
unstable. `docs/generate-plugin-plan.md` defines a strict daily full-sync
contract; this PR implements it as a new `@vuejs-community/generate`
workspace package.

The pipeline runs five stages per day:

1. **Replication scan** — prefix range queries against
   `replicate.npmjs.com/registry/_all_docs` with last-key cursor paging
   (PAGE_SIZE + 1 dedup guard) and `_changes` catch-up between
   start/end update sequences, so registry mutations during the scan
   cannot be missed.
2. **Package metadata** — one conditional request per package
   (`If-Modified-Since`); `304` responses must strictly match the cached
   entity (package name, hash, validator) or the run fails.
3. **Downloads** — statistics periods are anchored via the `npm` package
   (`last-day` / `last-month`), then every package gets explicit daily and
   monthly points through bulk requests (max 100 names, max 7000-char
   URLs); scoped packages are requested individually. Bulk responses must
   match the requested key set exactly.
4. **GitHub stars** — `repository → homepage → bugs.url` are parsed into
   normalized `owner/repo` targets and deduplicated; ETag conditional
   requests authenticated with `GENERATE_TOKEN` (5000 req/h) keep daily
   consumption near zero for unchanged repositories.
5. **Snapshot publish** — global validation (all four package sets equal,
   periods consistent, no duplicate output paths) followed by staging,
   re-validation of every written file, and an atomic directory swap.
   Any missing data means no snapshot is published.

Reliability measures: per-host rate limiters (replication 2/s, npm
registry 5/s, downloads 1/750ms, GitHub 2/s), exponential backoff with
`Retry-After` and rate-limit-reset awareness, and circuit breaking.
Run-internal state is intentionally not persisted — a crashed run simply
reruns, mostly hitting `304`. Only cross-run conditional-request
validators (npm `Last-Modified`, GitHub `ETag`) are kept, in two
schema-validated, gitignored JSON files under
`packages/generate/.sync-work/`.

Usage: `pnpm -F @vuejs-community/generate generate`

### 📝 Change Log

- Added the `@vuejs-community/generate` workspace package implementing the
  daily full-sync plugin snapshot pipeline (replication scan, metadata,
  downloads, GitHub stars, validated snapshot publish).
- Added `docs/generate-plugin-plan.md` describing the design contract and
  verified API behaviors.
- No impact on the site build or existing `data-*` packages; generated
  caches and snapshots are gitignored and never committed.
